### PR TITLE
Code was not wrapped in a try-catch block

### DIFF
--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/IntegrityConstraintParser.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/IntegrityConstraintParser.java
@@ -157,11 +157,14 @@ public class IntegrityConstraintParser implements OWLAxiomVisitor {
     }
 
     public void visit(OWLDataPropertyRangeAxiom axiom) {
-        OWLDataProperty op = Utils.ensureDataProperty(axiom.getProperty());
-        OWLDatatype clz = Utils.ensureDatatype(axiom.getRange());
+        try {
+            OWLDataProperty op = Utils.ensureDataProperty(axiom.getProperty());
+            OWLDatatype clz = Utils.ensureDatatype(axiom.getRange());
 
-        dpRanges.put(op, clz);
-        notSupported(axiom);
+            dpRanges.put(op, clz);
+        } catch (UnsupportedICException e) {
+            notSupported(axiom);
+        }
     }
 
     public void visit(OWLSymmetricObjectPropertyAxiom axiom) {


### PR DESCRIPTION
` visit(OWLSubClassOfAxiom axiom)` uses a try-catch block to call `notSupported()` if a `UnsupportedICException` is thrown.

The same mechanism was _not_ used in `visit(OWLDataPropertyRangeAxiom axiom)`, so the code never got to `notSupported()`, resulting in a `UnsupportedICException` bubbling up instead of simply generating a warning.