### PR TITLE
Revert "Minor version bump of owlapi"

### DIFF
--- a/jopa-owl2java/pom.xml
+++ b/jopa-owl2java/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.semanticweb</groupId>
             <artifactId>owlapi</artifactId>
-            <version>3.2.4</version>
+            <version>3.2.2</version>
             <type>jar</type>
         </dependency>
         <dependency>


### PR DESCRIPTION
Reverts kbss-cvut/jopa#21.

OWLAPI 3.2.4 is neither in Maven central nor in our local repository.