### PR TITLE
Bug/npx lazy load new persist

### DIFF
--- a/jopa-impl/src/main/java/cz/cvut/kbss/jopa/sessions/UnitOfWorkImpl.java
+++ b/jopa-impl/src/main/java/cz/cvut/kbss/jopa/sessions/UnitOfWorkImpl.java
@@ -236,8 +236,7 @@ public class UnitOfWorkImpl extends AbstractSession implements UnitOfWork, Confi
                         "Error while calculating changes for new objects. Original not found.");
             }
             newObjectsCloneToOriginal.put(clone, original);
-            changeSet.addNewObjectChangeSet(ChangeSetFactory.createObjectChangeSet(original, clone,
-                                                                                   c));
+            changeSet.addNewObjectChangeSet(ChangeSetFactory.createObjectChangeSet(original, clone, c));
         }
     }
 
@@ -706,8 +705,8 @@ public class UnitOfWorkImpl extends AbstractSession implements UnitOfWork, Confi
         cloneToOriginals.put(clone, original);
         final Object identifier = EntityPropertiesUtils.getIdentifier(clone, getMetamodel());
         keysToClones.put(identifier, clone);
-        instanceDescriptors
-                .put(clone, InstanceDescriptorFactory.create(clone, (EntityType<Object>) entityType(clone.getClass())));
+        final InstanceDescriptor<?> instanceDesc = identifier != null ? InstanceDescriptorFactory.create(clone, (EntityType<Object>) entityType(clone.getClass())) : InstanceDescriptorFactory.createAllLoaded(clone, (EntityType<Object>) entityType(clone.getClass()));
+        instanceDescriptors.put(clone, instanceDesc);
         registerEntityWithPersistenceContext(clone);
         registerEntityWithOntologyContext(clone, descriptor);
     }
@@ -759,7 +758,7 @@ public class UnitOfWorkImpl extends AbstractSession implements UnitOfWork, Confi
     private <T> void revertTransactionalChanges(T object, Descriptor descriptor, ObjectChangeSet chSet) {
         for (ChangeRecord change : chSet.getChanges()) {
             storage.merge(object, (FieldSpecification<? super T, ?>) change.getAttribute(),
-                          descriptor.getAttributeDescriptor(change.getAttribute()));
+                    descriptor.getAttributeDescriptor(change.getAttribute()));
         }
     }
 
@@ -995,7 +994,7 @@ public class UnitOfWorkImpl extends AbstractSession implements UnitOfWork, Confi
         Objects.requireNonNull(entity);
         final FieldSpecification<?, ?> fs = entityType(entity.getClass()).getFieldSpecification(attributeName);
         return instanceDescriptors.containsKey(entity) ? instanceDescriptors.get(entity).isLoaded(fs) :
-               LoadState.UNKNOWN;
+                LoadState.UNKNOWN;
     }
 
     @Override

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/OWLClassA.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/OWLClassA.java
@@ -46,7 +46,7 @@ public class OWLClassA implements HasUri {
     public static final String CONSTRUCTOR_MAPPING = "OWLClassA.constructorMapping";
     public static final String ENTITY_MAPPING = "OWLClassA.entityMapping";
 
-    @Types(fetchType = FetchType.EAGER)
+    @Types
     private Set<String> types;
 
     @Id
@@ -95,14 +95,14 @@ public class OWLClassA implements HasUri {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof OWLClassA)) return false;
         OWLClassA owlClassA = (OWLClassA) o;
-        return Objects.equals(uri, owlClassA.uri);
+        return Objects.equals(getTypes(), owlClassA.getTypes()) && Objects.equals(getUri(), owlClassA.getUri()) && Objects.equals(getStringAttribute(), owlClassA.getStringAttribute());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(uri);
+        return Objects.hash(getTypes(), getUri(), getStringAttribute());
     }
 
     @Override

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/environment/Generators.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/environment/Generators.java
@@ -177,9 +177,9 @@ public abstract class Generators {
 
     private static Set<String> getTypes() {
         final Set<String> types = new HashSet<>(3);
-        types.add("http://krizik.felk.cvut.cz/ontologies/jopa/entities#OWLClassA");
-        types.add("http://krizik.felk.cvut.cz/ontologies/jopa/entities#OWLClassX");
-        types.add("http://krizik.felk.cvut.cz/ontologies/jopa/entities#OWLClassZ");
+        types.add("http://krizik.felk.cvut.cz/ontologies/jopa/entities#OWLClassDF");
+        types.add("http://krizik.felk.cvut.cz/ontologies/jopa/entities#OWLClassDFF");
+        types.add("http://krizik.felk.cvut.cz/ontologies/jopa/entities#OWLClassDFFF");
         return types;
     }
 

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/query/QueryTestEnvironment.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/query/QueryTestEnvironment.java
@@ -255,7 +255,7 @@ public final class QueryTestEnvironment {
         final List<OWLClassM> lst = new ArrayList<>();
         for (int i = 0; i < ITEM_COUNT; i++) {
             final OWLClassM m = new OWLClassM();
-            m.setKey(Vocabulary.C_OWL_CLASS_M + Generators.randomPositiveInt(0, 10000));
+            m.setKey(Vocabulary.C_OWL_CLASS_M + Generators.randomPositiveInt(0, Integer.MAX_VALUE));
             m.setBooleanAttribute(Generators.randomBoolean());
             m.setDoubleAttribute(Generators.getRandomGenerator().nextDouble() * 100);
             m.setFloatAttribute(Generators.getRandomGenerator().nextFloat() * 100);

--- a/jopa-integration-tests/src/test/java/cz/cvut/kbss/jopa/test/integration/BugTest.java
+++ b/jopa-integration-tests/src/test/java/cz/cvut/kbss/jopa/test/integration/BugTest.java
@@ -26,7 +26,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.net.URI;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -169,5 +172,15 @@ class BugTest extends IntegrationTestBase {
         void prePersistChild() {
             this.childCallbackInvoked = true;
         }
+    }
+
+    @Test
+    void getterOnLazyAttributeWithNullValueAfterPersistDoesNotTriggerLazyFetch() {
+        final OWLClassF owner = new OWLClassF(Generators.generateUri());
+        final OWLClassA a = new OWLClassA();
+        owner.setSimpleSet(new HashSet<>(Collections.singletonList(a)));
+        em.getTransaction().begin();
+        em.persist(owner);
+        em.getTransaction().commit();
     }
 }

--- a/jopa-integration-tests/src/test/java/cz/cvut/kbss/jopa/test/integration/BugTest.java
+++ b/jopa-integration-tests/src/test/java/cz/cvut/kbss/jopa/test/integration/BugTest.java
@@ -14,7 +14,9 @@
  */
 package cz.cvut.kbss.jopa.test.integration;
 
+import cz.cvut.kbss.jopa.exceptions.RollbackException;
 import cz.cvut.kbss.jopa.model.annotations.*;
+import cz.cvut.kbss.jopa.oom.exceptions.UnpersistedChangeException;
 import cz.cvut.kbss.jopa.test.*;
 import cz.cvut.kbss.jopa.test.environment.Generators;
 import cz.cvut.kbss.jopa.vocabulary.RDFS;
@@ -181,6 +183,7 @@ class BugTest extends IntegrationTestBase {
         owner.setSimpleSet(new HashSet<>(Collections.singletonList(a)));
         em.getTransaction().begin();
         em.persist(owner);
-        em.getTransaction().commit();
+        final RollbackException ex = assertThrows(RollbackException.class, () -> em.getTransaction().commit());
+        assertInstanceOf(UnpersistedChangeException.class, ex.getCause());
     }
 }

--- a/jopa-integration-tests/src/test/java/cz/cvut/kbss/jopa/test/integration/PersistenceUnitUtilTest.java
+++ b/jopa-integration-tests/src/test/java/cz/cvut/kbss/jopa/test/integration/PersistenceUnitUtilTest.java
@@ -54,7 +54,6 @@ class PersistenceUnitUtilTest extends IntegrationTestBase {
         final OWLClassA entity = em.find(OWLClassA.class, uri);
         assertTrue(em.getEntityManagerFactory().getPersistenceUnitUtil().isLoaded(entity));
         assertTrue(em.getEntityManagerFactory().getPersistenceUnitUtil().isLoaded(entity, "stringAttribute"));
-        assertTrue(em.getEntityManagerFactory().getPersistenceUnitUtil().isLoaded(entity, "types"));
     }
 
     @Test


### PR DESCRIPTION
Fixes an NPX when an unpersisted non-initialized object was referenced in equals/hashCode of an entity.