### PR TITLE
Small changes in regards to multiple inheritance

### DIFF
--- a/jopa-api/src/main/java/cz/cvut/kbss/jopa/model/annotations/Enumerated.java
+++ b/jopa-api/src/main/java/cz/cvut/kbss/jopa/model/annotations/Enumerated.java
@@ -10,7 +10,7 @@ import java.lang.annotation.*;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.FIELD)
+@Target({ElementType.FIELD,ElementType.METHOD})
 public @interface Enumerated {
 
     /**

--- a/jopa-api/src/main/java/cz/cvut/kbss/jopa/model/annotations/Sequence.java
+++ b/jopa-api/src/main/java/cz/cvut/kbss/jopa/model/annotations/Sequence.java
@@ -27,7 +27,7 @@ import cz.cvut.kbss.jopa.model.SequencesVocabulary;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.FIELD)
+@Target({ElementType.FIELD,ElementType.METHOD})
 public @interface Sequence {
 
     /**

--- a/jopa-impl/src/main/java/cz/cvut/kbss/jopa/model/metamodel/AnnotatedAccessor.java
+++ b/jopa-impl/src/main/java/cz/cvut/kbss/jopa/model/metamodel/AnnotatedAccessor.java
@@ -114,4 +114,11 @@ public abstract class AnnotatedAccessor {
         }
     }
 
+    @Override
+    public String toString() {
+        return "AnnotatedAccessor{" +
+                "method=" + method +
+                ", propertyType=" + propertyType +
+                '}';
+    }
 }

--- a/jopa-impl/src/main/java/cz/cvut/kbss/jopa/model/metamodel/ClassFieldMetamodelProcessor.java
+++ b/jopa-impl/src/main/java/cz/cvut/kbss/jopa/model/metamodel/ClassFieldMetamodelProcessor.java
@@ -169,6 +169,8 @@ class ClassFieldMetamodelProcessor<X> {
                 Objects.equals(newMethod.getAnnotation(OWLDataProperty.class), foundMethod.getAnnotation(OWLDataProperty.class)) &&
                 Objects.equals(newMethod.getAnnotation(OWLAnnotationProperty.class), foundMethod.getAnnotation(OWLAnnotationProperty.class)) &&
                 Objects.equals(newMethod.getAnnotation(Convert.class), foundMethod.getAnnotation(Convert.class)) &&
+                Objects.equals(newMethod.getAnnotation(Sequence.class), foundMethod.getAnnotation(Sequence.class)) &&
+                Objects.equals(newMethod.getAnnotation(Enumerated.class), foundMethod.getAnnotation(Enumerated.class)) &&
                 Objects.equals(newMethod.getAnnotation(ParticipationConstraints.class), foundMethod.getAnnotation(ParticipationConstraints.class));
 
     }

--- a/jopa-impl/src/main/java/cz/cvut/kbss/jopa/model/metamodel/ClassFieldMetamodelProcessor.java
+++ b/jopa-impl/src/main/java/cz/cvut/kbss/jopa/model/metamodel/ClassFieldMetamodelProcessor.java
@@ -177,8 +177,14 @@ class ClassFieldMetamodelProcessor<X> {
 
 
     private boolean propertyBelongsToMethod(Field property, AnnotatedAccessor accessor) {
+        if (!property.getName().equals(accessor.getPropertyName())) {
+            return false;
+        }
+        if (!property.getType().isAssignableFrom(accessor.getPropertyType())) {
+            throw new MetamodelInitializationException("Non-compatible types between method " + accessor + " and field " + property.getName() + ". Method is accessor to type " + accessor.getPropertyType() + ", field type is "+property.getType());
+        }
 
-        return property.getName().equals(accessor.getPropertyName()) && property.getType().isAssignableFrom(accessor.getPropertyType());
+        return true;
     }
 
     private static Class<?> getFieldValueType(Field field) {
@@ -283,7 +289,8 @@ class ClassFieldMetamodelProcessor<X> {
         et.addDeclaredQueryAttribute(field.getName(), a);
     }
 
-    private AbstractAttribute<X, ?> createAttribute(PropertyInfo property, InferenceInfo inference, PropertyAttributes propertyAttributes) {
+    private AbstractAttribute<X, ?> createAttribute(PropertyInfo property, InferenceInfo
+            inference, PropertyAttributes propertyAttributes) {
         final AbstractAttribute<X, ?> a;
         if (property.getType().isAssignableFrom(Collection.class)) {
             final AbstractPluralAttribute.PluralAttributeBuilder builder = CollectionAttributeImpl.builder(propertyAttributes).declaringType(et).propertyInfo(property).inferred(inference.inferred).includeExplicit(inference.includeExplicit);
@@ -306,7 +313,8 @@ class ClassFieldMetamodelProcessor<X> {
         return a;
     }
 
-    private AbstractAttribute<X, ?> createListAttribute(PropertyInfo property, InferenceInfo inference, PropertyAttributes propertyAttributes) {
+    private AbstractAttribute<X, ?> createListAttribute(PropertyInfo property, InferenceInfo
+            inference, PropertyAttributes propertyAttributes) {
         final Sequence os = property.getAnnotation(Sequence.class);
         if (os == null) {
             throw new MetamodelInitializationException("Expected Sequence annotation.");

--- a/jopa-integration-tests-jena/src/test/java/cz/cvut/kbss/jopa/test/integration/jena/AnnotatedMethodsTest.java
+++ b/jopa-integration-tests-jena/src/test/java/cz/cvut/kbss/jopa/test/integration/jena/AnnotatedMethodsTest.java
@@ -1,0 +1,15 @@
+package cz.cvut.kbss.jopa.test.integration.jena;
+
+import cz.cvut.kbss.jopa.test.environment.JenaDataAccessor;
+import cz.cvut.kbss.jopa.test.environment.JenaPersistenceFactory;
+import cz.cvut.kbss.jopa.test.runner.AnnotatedMethodsTestRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AnnotatedMethodsTest extends AnnotatedMethodsTestRunner {
+    private static final Logger LOG = LoggerFactory.getLogger(AnnotatedMethodsTest.class);
+
+    public AnnotatedMethodsTest() {
+        super(LOG, new JenaPersistenceFactory(), new JenaDataAccessor());
+    }
+}

--- a/jopa-integration-tests-owlapi/src/test/java/cz/cvut/kbss/jopa/test/integration/owlapi/AnnotatedMethodsTest.java
+++ b/jopa-integration-tests-owlapi/src/test/java/cz/cvut/kbss/jopa/test/integration/owlapi/AnnotatedMethodsTest.java
@@ -1,0 +1,15 @@
+package cz.cvut.kbss.jopa.test.integration.owlapi;
+
+import cz.cvut.kbss.jopa.test.environment.OwlapiDataAccessor;
+import cz.cvut.kbss.jopa.test.environment.OwlapiPersistenceFactory;
+import cz.cvut.kbss.jopa.test.runner.AnnotatedMethodsTestRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AnnotatedMethodsTest  extends AnnotatedMethodsTestRunner {
+    private static final Logger LOG = LoggerFactory.getLogger(AnnotatedMethodsTest.class);
+
+    public AnnotatedMethodsTest() {
+        super(LOG, new OwlapiPersistenceFactory(), new OwlapiDataAccessor());
+    }
+}

--- a/jopa-integration-tests-rdf4j/src/test/java/cz/cvut/kbss/jopa/test/integration/rdf4j/AnnotatedMethodsTest.java
+++ b/jopa-integration-tests-rdf4j/src/test/java/cz/cvut/kbss/jopa/test/integration/rdf4j/AnnotatedMethodsTest.java
@@ -1,0 +1,15 @@
+package cz.cvut.kbss.jopa.test.integration.rdf4j;
+
+import cz.cvut.kbss.jopa.test.environment.Rdf4jDataAccessor;
+import cz.cvut.kbss.jopa.test.environment.Rdf4jPersistenceFactory;
+import cz.cvut.kbss.jopa.test.runner.AnnotatedMethodsTestRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AnnotatedMethodsTest extends AnnotatedMethodsTestRunner {
+    private static final Logger LOG = LoggerFactory.getLogger(AnnotatedMethodsTest.class);
+
+    public AnnotatedMethodsTest() {
+        super(LOG, new Rdf4jPersistenceFactory(), new Rdf4jDataAccessor());
+    }
+}

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/OWLClassWithAnnotatedMethodsInInterfaceParent.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/OWLClassWithAnnotatedMethodsInInterfaceParent.java
@@ -19,20 +19,23 @@ import cz.cvut.kbss.jopa.model.annotations.OWLClass;
 
 import java.net.URI;
 import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Set;
 
 @OWLClass(iri = Vocabulary.C_OWL_CLASS_PART_CONSTR_IN_PARENT)
-public class OWLClassWithPartConstraintsInInterfaceParent implements OWLInterfaceE {
+public class OWLClassWithAnnotatedMethodsInInterfaceParent implements OWLInterfaceE {
 
     protected OWLClassWithUnProperties data;
     protected Set<OWLClassWithUnProperties> dataList;
     protected ZoneOffset withConverter;
+    protected Color ordinalEnumAttribute;
+    protected List<URI> simpleList;
 
-    public OWLClassWithPartConstraintsInInterfaceParent(URI uri) {
+    public OWLClassWithAnnotatedMethodsInInterfaceParent(URI uri) {
         this.uri = uri;
     }
 
-    public OWLClassWithPartConstraintsInInterfaceParent() {
+    public OWLClassWithAnnotatedMethodsInInterfaceParent() {
     }
 
     @Id
@@ -71,5 +74,23 @@ public class OWLClassWithPartConstraintsInInterfaceParent implements OWLInterfac
 
     public void setWithConverter(ZoneOffset withConverter) {
         this.withConverter = withConverter;
+    }
+
+    @Override
+    public Color getOrdinalEnumAttribute() {
+        return ordinalEnumAttribute;
+    }
+
+    public void setOrdinalEnumAttribute(Color ordinalEnumAttribute) {
+        this.ordinalEnumAttribute = ordinalEnumAttribute;
+    }
+
+    @Override
+    public List<URI> getSimpleList() {
+        return simpleList;
+    }
+
+    public void setSimpleList(List<URI> simpleList) {
+        this.simpleList = simpleList;
     }
 }

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/OWLInterfaceE.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/OWLInterfaceE.java
@@ -2,13 +2,17 @@ package cz.cvut.kbss.jopa.test;
 
 import cz.cvut.kbss.jopa.model.annotations.*;
 
+import java.net.URI;
 import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Set;
 
 
 @OWLClass(iri = Vocabulary.C_OWL_INTERFACE_E)
 public interface OWLInterfaceE {
-
+    enum Color {
+        BLUE, BLACK, RED, GREEN
+    }
     @ParticipationConstraints(nonEmpty = true)
     @OWLObjectProperty(iri = Vocabulary.p_m_data, cascade = CascadeType.ALL)
     OWLClassWithUnProperties getData();
@@ -20,4 +24,13 @@ public interface OWLInterfaceE {
     @Convert(converter = ZoneOffsetConverter.class)
     @OWLDataProperty(iri = Vocabulary.p_m_withConverter, simpleLiteral = true)
     ZoneOffset getWithConverter();
+
+    @Enumerated(EnumType.ORDINAL)
+    @OWLDataProperty(iri = Vocabulary.p_m_enumeratedOrdinalColor)
+    Color getOrdinalEnumAttribute();
+
+    @Sequence(type = SequenceType.simple)
+    @OWLObjectProperty(iri = Vocabulary.p_m_simpleList)
+    List<URI> getSimpleList();
+
 }

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/Vocabulary.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/Vocabulary.java
@@ -90,6 +90,8 @@ public class Vocabulary {
     public static final String p_m_attributeB = ATTRIBUTE_IRI_BASE + "attributeB";
     public static final String p_m_data = ATTRIBUTE_IRI_BASE + "data";
     public static final String p_m_multiple_data = ATTRIBUTE_IRI_BASE + "multipleData";
+    public static final String p_m_enumeratedOrdinalColor = ATTRIBUTE_IRI_BASE + "enumeratedOrdinalColor";
+    public static final String p_m_simpleList = ATTRIBUTE_IRI_BASE + "simpleList";
 
     public static final String P_N_STR_ANNOTATION_PROPERTY = ATTRIBUTE_IRI_BASE + "annotationProperty";
     public static final String P_N_STRING_ATTRIBUTE = ATTRIBUTE_IRI_BASE + "N-stringAttribute";

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/AnnotatedMethodsTestRunner.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/AnnotatedMethodsTestRunner.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright (C) 2023 Czech Technical University in Prague
+ * <p>
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+package cz.cvut.kbss.jopa.test.runner;
+
+import cz.cvut.kbss.jopa.exceptions.RollbackException;
+import cz.cvut.kbss.jopa.test.*;
+import cz.cvut.kbss.jopa.test.environment.DataAccessor;
+import cz.cvut.kbss.jopa.test.environment.Generators;
+import cz.cvut.kbss.jopa.test.environment.PersistenceFactory;
+import cz.cvut.kbss.jopa.test.environment.Quad;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+
+import java.net.URI;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public abstract class AnnotatedMethodsTestRunner extends BaseRunner {
+    protected OWLClassWithAnnotatedMethodsInInterfaceParent classWithAnnotatedMethodsInInterfaceParent;
+    protected OWLClassWithUnProperties classWithUnProperties;
+
+    public AnnotatedMethodsTestRunner(Logger logger, PersistenceFactory persistenceFactory, DataAccessor dataAccessor) {
+        super(logger, persistenceFactory, dataAccessor);
+        classWithUnProperties = new OWLClassWithUnProperties(Generators.generateUri());
+
+        classWithAnnotatedMethodsInInterfaceParent = new OWLClassWithAnnotatedMethodsInInterfaceParent(Generators.generateUri());
+        classWithAnnotatedMethodsInInterfaceParent.setData(new OWLClassWithUnProperties(Generators.generateUri()));
+        classWithAnnotatedMethodsInInterfaceParent.setOrdinalEnumAttribute(OWLInterfaceE.Color.BLACK);
+    }
+
+    @Test
+    void nonEmptyParticipationConstraintsInInterfaceThrowExceptionIfNotMet() {
+        this.em = getEntityManager("nonEmptyParticipationConstraintsInInterfaceThrowExceptionIfNotMet", false);
+
+        /// violate constraints
+        classWithAnnotatedMethodsInInterfaceParent.setData(null);
+        em.getTransaction().begin();
+
+        em.persist(classWithAnnotatedMethodsInInterfaceParent);
+
+        assertThrows(RollbackException.class, () -> em.getTransaction().commit());
+
+    }
+
+    @Test
+    void nonEmptyParticipationConstraintsInInterfaceDoesNotThrowExceptionIfMet() {
+        this.em = getEntityManager("nonEmptyParticipationConstraintsInInterfaceDoesNotThrowExceptionIfMet", false);
+
+        em.getTransaction().begin();
+
+        em.persist(classWithAnnotatedMethodsInInterfaceParent);
+
+        em.getTransaction().commit();
+
+        verifyExists(OWLClassWithAnnotatedMethodsInInterfaceParent.class, classWithAnnotatedMethodsInInterfaceParent.getUri());
+    }
+
+
+    @Test
+    void maxParticipationConstraintsInInterfaceThrowExceptionIfNotMet() {
+        this.em = getEntityManager("maxParticipationConstraintsInInterfaceThrowExceptionIfNotMet", false);
+
+        Set<OWLClassWithUnProperties> dataList = new HashSet<>();
+        dataList.add(new OWLClassWithUnProperties(Generators.generateUri()));
+        dataList.add(new OWLClassWithUnProperties(Generators.generateUri()));
+        dataList.add(new OWLClassWithUnProperties(Generators.generateUri()));
+        classWithAnnotatedMethodsInInterfaceParent.setDataList(dataList);
+
+        em.getTransaction().begin();
+
+        em.persist(classWithAnnotatedMethodsInInterfaceParent);
+
+        assertThrows(RollbackException.class, () -> em.getTransaction().commit());
+    }
+
+    @Test
+    void maxParticipationConstraintsInInterfaceDoesNotThrowExceptionIfMet() {
+        this.em = getEntityManager("maxParticipationConstraintsInInterfaceDoesNotThrowExceptionIfMet", false);
+
+        Set<OWLClassWithUnProperties> dataList = new HashSet<>();
+        dataList.add(new OWLClassWithUnProperties(Generators.generateUri()));
+        dataList.add(new OWLClassWithUnProperties(Generators.generateUri()));
+        classWithAnnotatedMethodsInInterfaceParent.setDataList(dataList);
+
+        em.getTransaction().begin();
+
+        em.persist(classWithAnnotatedMethodsInInterfaceParent);
+
+        em.getTransaction().commit();
+
+        verifyExists(OWLClassWithAnnotatedMethodsInInterfaceParent.class, classWithAnnotatedMethodsInInterfaceParent.getUri());
+    }
+
+    @Test
+    void converterAnnotatedFieldsGetConverted() throws Exception {
+        this.em = getEntityManager("converterAnnotatedFieldsGetConverted", false);
+
+        classWithAnnotatedMethodsInInterfaceParent.setData(classWithUnProperties);
+
+        final ZoneOffset value = ZoneOffset.ofHours(2);
+        classWithAnnotatedMethodsInInterfaceParent.setWithConverter(value);
+
+        persist(classWithAnnotatedMethodsInInterfaceParent);
+
+        verifyStatementsPresent(Collections.singleton(
+                new Quad(classWithAnnotatedMethodsInInterfaceParent.getUri(), URI.create(Vocabulary.p_m_withConverter),
+                        classWithAnnotatedMethodsInInterfaceParent.getWithConverter().getId(), (String) null)), em);
+    }
+
+    @Test
+    void enumeratedAnnotatedFieldsPersistedCorrectly() throws Exception {
+            this.em = getEntityManager("enumeratedAnnotatedFieldsPersistedCorrectly", false);
+            persist(classWithAnnotatedMethodsInInterfaceParent);
+
+            verifyStatementsPresent(Collections.singletonList(
+                    new Quad(classWithAnnotatedMethodsInInterfaceParent.getUri(), URI.create(Vocabulary.p_m_enumeratedOrdinalColor),
+                            classWithAnnotatedMethodsInInterfaceParent.getOrdinalEnumAttribute().ordinal())), em);
+        }
+
+
+        @Test
+    void sequenceAnnotationGetsUpdatedCorrectly(){
+            this.em = getEntityManager("sequenceAnnotationGetsUpdatedCorrectly", true);
+            classWithAnnotatedMethodsInInterfaceParent.setSimpleList(Generators.createListOfIdentifiers());
+
+            persist(classWithAnnotatedMethodsInInterfaceParent);
+
+            final OWLClassWithAnnotatedMethodsInInterfaceParent update = findRequired(OWLClassWithAnnotatedMethodsInInterfaceParent.class, classWithAnnotatedMethodsInInterfaceParent.getUri());
+
+            em.getTransaction().begin();
+            for (int i = 0; i < Generators.randomPositiveInt(2, 20); i++) {
+                final URI u = URI.create("http://krizik.felk.cvut.cz/ontologies/jopa#Added-" + i);
+                // Insert at random position
+                update.getSimpleList().add(Generators.randomInt(update.getSimpleList().size()), u);
+            }
+            em.getTransaction().commit();
+
+            final OWLClassWithAnnotatedMethodsInInterfaceParent res = findRequired(OWLClassWithAnnotatedMethodsInInterfaceParent.class, classWithAnnotatedMethodsInInterfaceParent.getUri());
+            assertEquals(update.getSimpleList(), res.getSimpleList());
+        }
+
+
+}

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/MultipleInheritanceTestRunner.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/MultipleInheritanceTestRunner.java
@@ -35,13 +35,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public abstract class MultipleInheritanceTestRunner extends BaseRunner {
     protected OWLClassWithUnProperties classWithUnProperties;
-    protected OWLClassWithPartConstraintsInInterfaceParent classWithPartConstraintsInInterfaceParent;
 
     public MultipleInheritanceTestRunner(Logger logger, PersistenceFactory persistenceFactory, DataAccessor dataAccessor) {
         super(logger, persistenceFactory, dataAccessor);
         classWithUnProperties = new OWLClassWithUnProperties(Generators.generateUri());
-        classWithPartConstraintsInInterfaceParent = new OWLClassWithPartConstraintsInInterfaceParent(Generators.generateUri());
-        classWithPartConstraintsInInterfaceParent.setData(new OWLClassWithUnProperties(Generators.generateUri()));
     }
 
 
@@ -137,87 +134,6 @@ public abstract class MultipleInheritanceTestRunner extends BaseRunner {
         assertEquals(child.getAttributeB(), found.getAttributeB());
 
         assertEquals(child.getName(), commonParentFound.getName());
-    }
-
-
-    @Test
-    void nonEmptyParticipationConstraintsInInterfaceThrowExceptionIfNotMet() {
-        this.em = getEntityManager("nonEmptyParticipationConstraintsInInterfaceThrowExceptionIfNotMet", false);
-
-        /// violate constraints
-        classWithPartConstraintsInInterfaceParent.setData(null);
-        em.getTransaction().begin();
-
-        em.persist(classWithPartConstraintsInInterfaceParent);
-
-        assertThrows(RollbackException.class, () -> em.getTransaction().commit());
-
-    }
-
-    @Test
-    void nonEmptyParticipationConstraintsInInterfaceDoesNotThrowExceptionIfMet() {
-        this.em = getEntityManager("nonEmptyParticipationConstraintsInInterfaceDoesNotThrowExceptionIfMet", false);
-
-
-        em.getTransaction().begin();
-
-        em.persist(classWithPartConstraintsInInterfaceParent);
-
-        em.getTransaction().commit();
-
-        verifyExists(OWLClassWithPartConstraintsInInterfaceParent.class, classWithPartConstraintsInInterfaceParent.getUri());
-    }
-
-
-    @Test
-    void maxParticipationConstraintsInInterfaceThrowExceptionIfNotMet() {
-        this.em = getEntityManager("maxParticipationConstraintsInInterfaceThrowExceptionIfNotMet", false);
-
-        Set<OWLClassWithUnProperties> dataList = new HashSet<>();
-        dataList.add(new OWLClassWithUnProperties(Generators.generateUri()));
-        dataList.add(new OWLClassWithUnProperties(Generators.generateUri()));
-        dataList.add(new OWLClassWithUnProperties(Generators.generateUri()));
-        classWithPartConstraintsInInterfaceParent.setDataList(dataList);
-
-        em.getTransaction().begin();
-
-        em.persist(classWithPartConstraintsInInterfaceParent);
-
-        assertThrows(RollbackException.class, () -> em.getTransaction().commit());
-    }
-
-    @Test
-    void maxParticipationConstraintsInInterfaceDoesNotThrowExceptionIfMet() {
-        this.em = getEntityManager("maxParticipationConstraintsInInterfaceDoesNotThrowExceptionIfMet", false);
-
-        Set<OWLClassWithUnProperties> dataList = new HashSet<>();
-        dataList.add(new OWLClassWithUnProperties(Generators.generateUri()));
-        dataList.add(new OWLClassWithUnProperties(Generators.generateUri()));
-        classWithPartConstraintsInInterfaceParent.setDataList(dataList);
-
-        em.getTransaction().begin();
-
-        em.persist(classWithPartConstraintsInInterfaceParent);
-
-        em.getTransaction().commit();
-
-        verifyExists(OWLClassWithPartConstraintsInInterfaceParent.class, classWithPartConstraintsInInterfaceParent.getUri());
-    }
-
-    @Test
-    void converterAnnotatedFieldsGetConverted() throws Exception {
-        this.em = getEntityManager("converterAnnotatedFieldsGetConverted", false);
-
-        classWithPartConstraintsInInterfaceParent.setData(classWithUnProperties);
-
-        final ZoneOffset value = ZoneOffset.ofHours(2);
-        classWithPartConstraintsInInterfaceParent.setWithConverter(value);
-
-        persist(classWithPartConstraintsInInterfaceParent);
-
-        verifyStatementsPresent(Collections.singleton(
-                new Quad(classWithPartConstraintsInInterfaceParent.getUri(), URI.create(Vocabulary.p_m_withConverter),
-                        classWithPartConstraintsInInterfaceParent.getWithConverter().getId(), (String) null)), em);
     }
 
     @Test


### PR DESCRIPTION
Minor changes to enable more annotations on accessor methods and to preemptively fail on invalid hierarchies.

- `@Enumerated` and `@Sequence` are now supported on methods
- An exception is thrown if types mismatch during field processing  

#157