### PR TITLE
Bug/191 rdf4j driver connection pool deadlock

### DIFF
--- a/ontodriver-api/src/main/java/cz/cvut/kbss/ontodriver/config/DriverConfiguration.java
+++ b/ontodriver-api/src/main/java/cz/cvut/kbss/ontodriver/config/DriverConfiguration.java
@@ -83,6 +83,23 @@ public final class DriverConfiguration {
     }
 
     /**
+     * Gets integer value of the specified property or the default value, if the property is not set.
+     *
+     * @param property     Parameter
+     * @param defaultValue Value to return if the property is not set
+     * @return Value of the property or {@code defaultValue}, if it is not set
+     * @throws IllegalArgumentException If the configured property value is not an integer
+     */
+    public int getProperty(ConfigurationParameter property, int defaultValue) {
+        final String propertyValue = getProperty(property, Integer.toString(defaultValue));
+        try {
+            return Integer.parseInt(propertyValue);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Value '" + propertyValue + "' of property '" + propertyValue + "' is not a valid integer.", e);
+        }
+    }
+
+    /**
      * Returns value of the specified property as boolean.
      * <p>
      * If the property is not configured, {@code false} is returned.

--- a/ontodriver-api/src/test/java/cz/cvut/kbss/ontodriver/config/DriverConfigurationTest.java
+++ b/ontodriver-api/src/test/java/cz/cvut/kbss/ontodriver/config/DriverConfigurationTest.java
@@ -60,4 +60,25 @@ class DriverConfigurationTest {
     void getAsBooleanReturnsFalseForUnknownProperty() {
         assertFalse(configuration.is(DriverConfigParam.AUTO_COMMIT));
     }
+
+    @Test
+    void getPropertyAsIntegerReturnsParsedPropertyValue() {
+        configuration.setProperty(TestConfigParameter.INTEGER_PARAM, "117");
+        assertEquals(117, configuration.getProperty(TestConfigParameter.INTEGER_PARAM, 1));
+    }
+
+    @Test
+    void getPropertyAsIntegerReturnsDefaultValueWhenPropertyIsNotConfigured() {
+        assertEquals(1, configuration.getProperty(TestConfigParameter.INTEGER_PARAM, 1));
+    }
+
+    @Test
+    void getPropertyAsIntegerThrowsIllegalArgumentExceptionWhenConfiguredPropertyValueIsNotInteger() {
+        configuration.setProperty(TestConfigParameter.INTEGER_PARAM, "dkde");
+        assertThrows(IllegalArgumentException.class, () -> configuration.getProperty(TestConfigParameter.INTEGER_PARAM, 1));
+    }
+
+    private enum TestConfigParameter implements ConfigurationParameter {
+        INTEGER_PARAM
+    }
 }

--- a/ontodriver-rdf4j/src/main/java/cz/cvut/kbss/ontodriver/rdf4j/config/Constants.java
+++ b/ontodriver-rdf4j/src/main/java/cz/cvut/kbss/ontodriver/rdf4j/config/Constants.java
@@ -38,6 +38,20 @@ public class Constants {
      */
     public static final int DEFAULT_RECONNECT_ATTEMPTS_COUNT = 5;
 
+    /**
+     * Default maximum connection pool size.
+     *
+     * @see Rdf4jOntoDriverProperties#MAX_CONNECTION_POOL_SIZE
+     */
+    public static final int DEFAULT_MAX_CONNECTIONS = 5;
+
+    /**
+     * Default connection request timeout (in milliseconds).
+     *
+     * @see Rdf4jOntoDriverProperties#CONNECTION_REQUEST_TIMEOUT
+     */
+    public static final int DEFAULT_CONNECTION_REQUEST_TIMEOUT = 1000;
+
     private Constants() {
         throw new AssertionError();
     }

--- a/ontodriver-rdf4j/src/main/java/cz/cvut/kbss/ontodriver/rdf4j/config/Rdf4jConfigParam.java
+++ b/ontodriver-rdf4j/src/main/java/cz/cvut/kbss/ontodriver/rdf4j/config/Rdf4jConfigParam.java
@@ -32,7 +32,9 @@ public enum Rdf4jConfigParam implements ConfigurationParameter {
     PASSWORD(OntoDriverProperties.DATA_SOURCE_PASSWORD),
     REPOSITORY_CONFIG(Rdf4jOntoDriverProperties.REPOSITORY_CONFIG),
     RECONNECT_ATTEMPTS(Rdf4jOntoDriverProperties.RECONNECT_ATTEMPTS),
-    INFERENCE_IN_DEFAULT_CONTEXT(Rdf4jOntoDriverProperties.INFERENCE_IN_DEFAULT_CONTEXT);
+    INFERENCE_IN_DEFAULT_CONTEXT(Rdf4jOntoDriverProperties.INFERENCE_IN_DEFAULT_CONTEXT),
+    CONNECTION_REQUEST_TIMEOUT(Rdf4jOntoDriverProperties.CONNECTION_REQUEST_TIMEOUT),
+    MAX_CONNECTION_POOL_SIZE(Rdf4jOntoDriverProperties.MAX_CONNECTION_POOL_SIZE);
 
     private final String name;
 

--- a/ontodriver-rdf4j/src/main/java/cz/cvut/kbss/ontodriver/rdf4j/config/Rdf4jOntoDriverProperties.java
+++ b/ontodriver-rdf4j/src/main/java/cz/cvut/kbss/ontodriver/rdf4j/config/Rdf4jOntoDriverProperties.java
@@ -64,9 +64,9 @@ public abstract class Rdf4jOntoDriverProperties {
      * be loaded using the value as file path. The loaded configuration supersedes relevant properties passed to the
      * driver, e.g., {@link #USE_VOLATILE_STORAGE} or {@link #USE_INFERENCE}.
      * <p>
-     * Note that the config applies only to embedded repositories created by the driver, repositories on a RDF4J
-     * server to which the driver just connects must preexist and the configuration does not apply to them. The physical
-     * URI specified in configuration must correspond to the URI of the repository in the config file, i.e., for memory
+     * Note that the config applies only to embedded repositories created by the driver, repositories on a RDF4J server
+     * to which the driver just connects must preexist and the configuration does not apply to them. The physical URI
+     * specified in configuration must correspond to the URI of the repository in the config file, i.e., for memory
      * store, the repository ID must be the same. For a native store, the physical URI must be in the form {@code
      * /local-path/repositories/repository-id}, where {@code local-path} will be used for initialization of a local
      * {@link org.eclipse.rdf4j.repository.manager.RepositoryManager} and {@code repository-id} must again correspond to
@@ -98,8 +98,31 @@ public abstract class Rdf4jOntoDriverProperties {
      * <p>
      * Defaults to {@code false}, i.e., inferred statements are expected in the same context as their causes.
      */
-    public static final String INFERENCE_IN_DEFAULT_CONTEXT =
-            "cz.cvut.kbss.ontodriver.rdf4j.inference-in-default-context";
+    public static final String INFERENCE_IN_DEFAULT_CONTEXT = "cz.cvut.kbss.ontodriver.rdf4j.inference-in-default-context";
+
+    /**
+     * Timeout for the underlying HTTP client to request a connection to the remote repository from the connection
+     * pool.
+     * <p>
+     * RDF4J internally uses the Apache HTTP Client with a connection pool that is able to grow up to a configured
+     * limit. When the pool is exhausted and the driver requests another connection, it may happen that no connection is
+     * available will become available, possibly leading to a deadlock. This parameter sets a timeout for the connection
+     * acquisition requests from the pool, so that the application is able to fail gracefully in case of too much load
+     * and does not get stuck.
+     * <p>
+     * The value should be an integer corresponding to the number of milliseconds.
+     * <p>
+     * Applies only to instances connected to a RDF4J server.
+     */
+    public static final String CONNECTION_REQUEST_TIMEOUT = "cz.cvut.kbss.ontodriver.rdf4j.connection-request-timeout";
+
+    /**
+     * Maximum size of the underlying HTTP client connection pool.
+     * <p>
+     * RDF4J internally uses the Apache HTTP Client with a connection pool that is able to grow up to a configured
+     * limit. This parameter allows to set this limit.
+     */
+    public static final String MAX_CONNECTION_POOL_SIZE = "cz.cvut.kbss.ontodriver.rdf4j.max-connections";
 
     private Rdf4jOntoDriverProperties() {
         throw new AssertionError();

--- a/ontodriver-rdf4j/src/main/java/cz/cvut/kbss/ontodriver/rdf4j/connector/StorageConnector.java
+++ b/ontodriver-rdf4j/src/main/java/cz/cvut/kbss/ontodriver/rdf4j/connector/StorageConnector.java
@@ -14,6 +14,7 @@
  */
 package cz.cvut.kbss.ontodriver.rdf4j.connector;
 
+import cz.cvut.kbss.ontodriver.Wrapper;
 import cz.cvut.kbss.ontodriver.exception.OntoDriverException;
 import cz.cvut.kbss.ontodriver.rdf4j.connector.init.RepositoryConnectorInitializer;
 import cz.cvut.kbss.ontodriver.rdf4j.exception.Rdf4jDriverException;
@@ -258,6 +259,9 @@ public class StorageConnector extends AbstractConnector {
         }
         if (cls.isAssignableFrom(repository.getClass())) {
             return cls.cast(repository);
+        }
+        if (repository instanceof Wrapper) {
+            return ((Wrapper) repository).unwrap(cls);
         }
         throw new Rdf4jDriverException("No instance of class " + cls + " found.");
     }

--- a/ontodriver-rdf4j/src/main/java/cz/cvut/kbss/ontodriver/rdf4j/connector/init/HttpClientFactory.java
+++ b/ontodriver-rdf4j/src/main/java/cz/cvut/kbss/ontodriver/rdf4j/connector/init/HttpClientFactory.java
@@ -56,7 +56,7 @@ class HttpClientFactory {
 
     private static int getMaxConnections(DriverConfiguration config) {
         final int defaultMaxConnections = Math.max(Constants.DEFAULT_MAX_CONNECTIONS, Runtime.getRuntime()
-                                                                                             .availableProcessors());
+                                                                                             .availableProcessors() * 2);
         return config.getProperty(Rdf4jConfigParam.MAX_CONNECTION_POOL_SIZE, defaultMaxConnections);
     }
 

--- a/ontodriver-rdf4j/src/main/java/cz/cvut/kbss/ontodriver/rdf4j/connector/init/HttpClientFactory.java
+++ b/ontodriver-rdf4j/src/main/java/cz/cvut/kbss/ontodriver/rdf4j/connector/init/HttpClientFactory.java
@@ -35,6 +35,8 @@ class HttpClientFactory {
         final RequestConfig customRequestConfig = RequestConfig.custom()
                                                                .setCookieSpec(CookieSpecs.STANDARD)
                                                                .setConnectionRequestTimeout(1000).build();
+        // TODO Configurable connection request timeout
+        // TODO Set larger max connections and max connections per route
         return HttpClientBuilder.create()
                                 .evictExpiredConnections()
                                 .setRetryHandler(new RetryHandlerStale())

--- a/ontodriver-rdf4j/src/main/java/cz/cvut/kbss/ontodriver/rdf4j/connector/init/HttpClientFactory.java
+++ b/ontodriver-rdf4j/src/main/java/cz/cvut/kbss/ontodriver/rdf4j/connector/init/HttpClientFactory.java
@@ -1,6 +1,7 @@
 package cz.cvut.kbss.ontodriver.rdf4j.connector.init;
 
 import cz.cvut.kbss.ontodriver.config.DriverConfiguration;
+import cz.cvut.kbss.ontodriver.rdf4j.config.Constants;
 import cz.cvut.kbss.ontodriver.rdf4j.config.Rdf4jConfigParam;
 import org.apache.http.HttpConnection;
 import org.apache.http.HttpResponse;
@@ -22,11 +23,6 @@ import java.net.HttpURLConnection;
 class HttpClientFactory {
 
     /**
-     * Default max connection pool size.
-     */
-    private static final int DEFAULT_MAX_CONNECTIONS = 5;
-
-    /**
      * Creates a customized {@link HttpClient} instance.
      * <p>
      * The client's configuration is basically the same as the default one used by RDF4J, but it sets a timeout on
@@ -39,8 +35,8 @@ class HttpClientFactory {
     static HttpClient createHttpClient(DriverConfiguration configuration) {
         final RequestConfig customRequestConfig = RequestConfig.custom()
                                                                .setCookieSpec(CookieSpecs.STANDARD)
-                                                               .setConnectionRequestTimeout(1000).build();
-        // TODO Configurable connection request timeout
+                                                               .setConnectionRequestTimeout(getConnectionRequestTimeout(configuration))
+                                                               .build();
         final int maxConnections = getMaxConnections(configuration);
         return HttpClientBuilder.create()
                                 .evictExpiredConnections()
@@ -54,8 +50,13 @@ class HttpClientFactory {
                                 .setDefaultRequestConfig(customRequestConfig).build();
     }
 
+    private static int getConnectionRequestTimeout(DriverConfiguration config) {
+        return config.getProperty(Rdf4jConfigParam.CONNECTION_REQUEST_TIMEOUT, Constants.DEFAULT_CONNECTION_REQUEST_TIMEOUT);
+    }
+
     private static int getMaxConnections(DriverConfiguration config) {
-        final int defaultMaxConnections = Math.max(DEFAULT_MAX_CONNECTIONS, Runtime.getRuntime().availableProcessors());
+        final int defaultMaxConnections = Math.max(Constants.DEFAULT_MAX_CONNECTIONS, Runtime.getRuntime()
+                                                                                             .availableProcessors());
         return config.getProperty(Rdf4jConfigParam.MAX_CONNECTION_POOL_SIZE, defaultMaxConnections);
     }
 

--- a/ontodriver-rdf4j/src/main/java/cz/cvut/kbss/ontodriver/rdf4j/connector/init/HttpClientFactory.java
+++ b/ontodriver-rdf4j/src/main/java/cz/cvut/kbss/ontodriver/rdf4j/connector/init/HttpClientFactory.java
@@ -1,0 +1,126 @@
+package cz.cvut.kbss.ontodriver.rdf4j.connector.init;
+
+import cz.cvut.kbss.ontodriver.config.DriverConfiguration;
+import org.apache.http.HttpConnection;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.HttpRequestRetryHandler;
+import org.apache.http.client.ServiceUnavailableRetryStrategy;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.protocol.HttpContext;
+import org.eclipse.rdf4j.http.client.SharedHttpClientSessionManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+class HttpClientFactory {
+
+    /**
+     * Creates a customized {@link HttpClient} instance.
+     * <p>
+     * The client's configuration is basically the same as the default one used by RDF4J, but it sets a timeout on
+     * connection requests from the connection pool, so that an application with exhausted connection pool fails
+     * gracefully instead of potentially going into a deadlock.
+     *
+     * @param configuration Driver configuration
+     *
+     * @return HttpClient instance with connection pool request timeout
+     */
+    static HttpClient createHttpClient(DriverConfiguration configuration) {
+        final RequestConfig customRequestConfig = RequestConfig.custom()
+                                                               .setCookieSpec(CookieSpecs.STANDARD)
+                                                               .setConnectionRequestTimeout(1000).build();
+        return HttpClientBuilder.create()
+                                .evictExpiredConnections()
+                                .setRetryHandler(new RetryHandlerStale())
+                                .setServiceUnavailableRetryStrategy(new ServiceUnavailableRetryHandler())
+                                .useSystemProperties()
+                                .setDefaultRequestConfig(customRequestConfig).build();
+    }
+
+    /**
+     * Copied from {@link SharedHttpClientSessionManager}
+     */
+    private static class RetryHandlerStale implements HttpRequestRetryHandler {
+        private final Logger logger = LoggerFactory.getLogger(RetryHandlerStale.class);
+
+        @Override
+        public boolean retryRequest(IOException ioe, int count, HttpContext context) {
+            // only try this once
+            if (count > 1) {
+                return false;
+            }
+            HttpClientContext clientContext = HttpClientContext.adapt(context);
+            HttpConnection conn = clientContext.getConnection();
+            if (conn != null) {
+                synchronized (this) {
+                    if (conn.isStale()) {
+                        try {
+                            logger.warn("Closing stale connection");
+                            conn.close();
+                            return true;
+                        } catch (IOException e) {
+                            logger.error("Error closing stale connection", e);
+                        }
+                    }
+                }
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Copied from {@link SharedHttpClientSessionManager}
+     */
+    private static class ServiceUnavailableRetryHandler implements ServiceUnavailableRetryStrategy {
+        private final Logger logger = LoggerFactory.getLogger(ServiceUnavailableRetryHandler.class);
+
+        @Override
+        public boolean retryRequest(HttpResponse response, int executionCount, HttpContext context) {
+            // only retry on `408`
+            if (response.getStatusLine().getStatusCode() != HttpURLConnection.HTTP_CLIENT_TIMEOUT) {
+                return false;
+            }
+
+            // when `keepAlive` is disabled every connection is fresh (with the default `useSystemProperties` http
+            // client configuration we use), a 408 in that case is an unexpected issue we don't handle here
+            String keepAlive = System.getProperty("http.keepAlive", "true");
+            if (!"true".equalsIgnoreCase(keepAlive)) {
+                return false;
+            }
+
+            // worst case, the connection pool is filled to the max and all of them idled out on the server already
+            // we then need to clean up the pool and finally retry with a fresh connection. Hence, we need at most
+            // pooledConnections+1 retries.
+            // the pool size setting used here is taken from `HttpClientBuilder` when `useSystemProperties()` is used
+            int pooledConnections = Integer.parseInt(System.getProperty("http.maxConnections", "5"));
+            if (executionCount > (pooledConnections + 1)) {
+                return false;
+            }
+
+            HttpClientContext clientContext = HttpClientContext.adapt(context);
+            HttpConnection conn = clientContext.getConnection();
+
+            synchronized (this) {
+                try {
+                    logger.info("Cleaning up closed connection");
+                    conn.close();
+                    return true;
+                } catch (IOException e) {
+                    logger.error("Error cleaning up closed connection", e);
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public long getRetryInterval() {
+            return 1000;
+        }
+    }
+}

--- a/ontodriver-rdf4j/src/main/java/cz/cvut/kbss/ontodriver/rdf4j/connector/init/RemoteRepositoryWrapper.java
+++ b/ontodriver-rdf4j/src/main/java/cz/cvut/kbss/ontodriver/rdf4j/connector/init/RemoteRepositoryWrapper.java
@@ -1,0 +1,87 @@
+package cz.cvut.kbss.ontodriver.rdf4j.connector.init;
+
+import cz.cvut.kbss.ontodriver.Wrapper;
+import cz.cvut.kbss.ontodriver.config.DriverConfiguration;
+import cz.cvut.kbss.ontodriver.exception.OntoDriverException;
+import cz.cvut.kbss.ontodriver.rdf4j.exception.Rdf4jDriverException;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.utils.HttpClientUtils;
+import org.eclipse.rdf4j.http.client.HttpClientSessionManager;
+import org.eclipse.rdf4j.http.client.SharedHttpClientSessionManager;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.repository.http.HTTPRepository;
+
+import java.io.File;
+
+/**
+ * Wrapper for RDF4J {@link HTTPRepository} allowing to set custom {@link HttpClient} for it to use.
+ */
+public class RemoteRepositoryWrapper implements Repository, Wrapper {
+
+    private final HTTPRepository delegate;
+    private HttpClient httpClient;
+
+    public RemoteRepositoryWrapper(HTTPRepository delegate, DriverConfiguration configuration) {
+        this.delegate = delegate;
+        this.httpClient = HttpClientFactory.createHttpClient(configuration);
+        final HttpClientSessionManager sessionManager = delegate.getHttpClientSessionManager();
+        if (sessionManager instanceof SharedHttpClientSessionManager) {
+            ((SharedHttpClientSessionManager) sessionManager).setHttpClient(httpClient);
+        }
+    }
+
+    @Override
+    public void setDataDir(File file) {
+        delegate.setDataDir(file);
+    }
+
+    @Override
+    public File getDataDir() {
+        return delegate.getDataDir();
+    }
+
+    @Override
+    public void init() throws RepositoryException {
+        delegate.init();
+    }
+
+    @Override
+    public boolean isInitialized() {
+        return delegate.isInitialized();
+    }
+
+    @Override
+    public void shutDown() throws RepositoryException {
+        delegate.shutDown();
+        if (httpClient != null) {
+            HttpClientUtils.closeQuietly(httpClient);
+            this.httpClient = null;
+        }
+    }
+
+    @Override
+    public boolean isWritable() throws RepositoryException {
+        return delegate.isWritable();
+    }
+
+    @Override
+    public RepositoryConnection getConnection() throws RepositoryException {
+        return delegate.getConnection();
+    }
+
+    @Override
+    public ValueFactory getValueFactory() {
+        return delegate.getValueFactory();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> cls) throws OntoDriverException {
+        if (cls.isAssignableFrom(delegate.getClass())) {
+            return cls.cast(delegate);
+        }
+        throw new Rdf4jDriverException("No instance of class " + cls + " found.");
+    }
+}

--- a/ontodriver-rdf4j/src/main/java/cz/cvut/kbss/ontodriver/rdf4j/connector/init/RepositoryConnectorInitializer.java
+++ b/ontodriver-rdf4j/src/main/java/cz/cvut/kbss/ontodriver/rdf4j/connector/init/RepositoryConnectorInitializer.java
@@ -1,16 +1,14 @@
 /**
  * Copyright (C) 2023 Czech Technical University in Prague
- *
- * This program is free software: you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation, either version 3 of the License, or (at your option) any
- * later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- * details. You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * <p>
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
  */
 package cz.cvut.kbss.ontodriver.rdf4j.connector.init;
 
@@ -30,6 +28,7 @@ import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.config.RepositoryConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigSchema;
+import org.eclipse.rdf4j.repository.http.HTTPRepository;
 import org.eclipse.rdf4j.repository.manager.RemoteRepositoryManager;
 import org.eclipse.rdf4j.repository.manager.RepositoryManager;
 import org.eclipse.rdf4j.repository.manager.RepositoryProvider;
@@ -77,7 +76,7 @@ public class RepositoryConnectorInitializer {
         try {
             final int attempts = configuration.isSet(Rdf4jConfigParam.RECONNECT_ATTEMPTS) ? Integer.parseInt(
                     configuration.getProperty(Rdf4jConfigParam.RECONNECT_ATTEMPTS)) :
-                                 Constants.DEFAULT_RECONNECT_ATTEMPTS_COUNT;
+                    Constants.DEFAULT_RECONNECT_ATTEMPTS_COUNT;
             if (attempts < 0) {
                 throw invalidReconnectAttemptsConfig();
             }
@@ -133,7 +132,7 @@ public class RepositoryConnectorInitializer {
 
     private Repository connectToRemote(String repoUri, int attempts) {
         try {
-            return manager.getRepository(RepositoryProvider.getRepositoryIdOfRepository(repoUri));
+            return new RemoteRepositoryWrapper((HTTPRepository) manager.getRepository(RepositoryProvider.getRepositoryIdOfRepository(repoUri)), configuration);
         } catch (RepositoryException e) {
             if (attempts < maxReconnectAttempts) {
                 LOG.warn("Unable to connect to repository {}. Error is: {}. Retrying...", repoUri, e.getMessage());
@@ -198,7 +197,7 @@ public class RepositoryConnectorInitializer {
                 return new FileInputStream(configPath);
             } catch (FileNotFoundException e) {
                 throw new RepositoryCreationException("Unable to find repository configuration file at " + configPath,
-                                                      e);
+                        e);
             }
         }
     }


### PR DESCRIPTION
Fixes #191 .

Adds a (configurable) connection request timeout so that connection pool exhaustion can be handled by the application. Also allows configuring the size of the connection pool.