### PR TITLE
[Fix] Revert maven-source-plugin to 3.2.1 due to build failures.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.3.0</version>
+                        <version>3.2.1</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MSOURCES-141