### PR TITLE
Enhancement#85 owl2java term disambiguation by prefixes

### DIFF
--- a/jopa-api/src/main/java/cz/cvut/kbss/jopa/vocabulary/SKOS.java
+++ b/jopa-api/src/main/java/cz/cvut/kbss/jopa/vocabulary/SKOS.java
@@ -30,6 +30,11 @@ public final class SKOS {
     public static final String NAMESPACE = "http://www.w3.org/2004/02/skos/core#";
 
     /**
+     * Typical prefix used for {@link #NAMESPACE}.
+     */
+    public static final String PREFIX = "skos";
+
+    /**
      * SKOS <a href="https://www.w3.org/2009/08/skos-reference/skos.html#Collection">Collection</a> class.
      *
      * @see <a href="http://www.w3.org/TR/skos-reference/#collections">http://www.w3.org/TR/skos-reference/#collections</a>

--- a/jopa-maven-plugin/src/main/java/cz/cvut/kbss/jopa/maven/OWL2JavaMojo.java
+++ b/jopa-maven-plugin/src/main/java/cz/cvut/kbss/jopa/maven/OWL2JavaMojo.java
@@ -42,6 +42,9 @@ public class OWL2JavaMojo extends AbstractMojo {
     private static final String PREFER_MULTILINGUAL_STRINGS = "prefer-multilingual-strings";
     private static final String GENERATE_ANNOTATION_FIELDS = "generate-annotation-fields";
     private static final String GENERATE_THING = "generate-thing";
+    private static final String ONTOLOGY_PREFIX_PROPERTY = "ontology-prefix-property";
+    private static final String ALWAYS_USE_PREFIXES = "always-use-prefixes";
+    private static final String PREFIX_MAPPING_FILE = "prefix-mapping-file";
 
     @Parameter(name = MAPPING_FILE_PARAM)
     private String mappingFile;
@@ -85,6 +88,15 @@ public class OWL2JavaMojo extends AbstractMojo {
     @Parameter(name = GENERATE_THING, defaultValue = "true")
     private boolean generateThing;
 
+    @Parameter(name = ONTOLOGY_PREFIX_PROPERTY)
+    private String ontologyPrefixProperty;
+
+    @Parameter(name = ALWAYS_USE_PREFIXES, defaultValue = "false")
+    private boolean alwaysUsePrefixes;
+
+    @Parameter(name = PREFIX_MAPPING_FILE)
+    private String prefixMappingFile;
+
     @Override
     public void execute() {
         OWL2JavaTransformer owl2java = new OWL2JavaTransformer();
@@ -117,7 +129,9 @@ public class OWL2JavaMojo extends AbstractMojo {
         final TransformationConfiguration config =
                 builder.packageName(pPackage).targetDir(outputDirectory).addOwlapiIris(withOwlapi)
                        .generateJavadoc(javadocFromRdfsComment).preferMultilingualStrings(preferMultilingualStrings)
-                       .generateAnnotationFields(generateAnnotationFields).generateThing(generateThing).build();
+                       .generateAnnotationFields(generateAnnotationFields).generateThing(generateThing)
+                       .ontologyPrefixProperty(ontologyPrefixProperty).alwaysUseOntologyPrefix(alwaysUsePrefixes)
+                       .prefixMappingFile(prefixMappingFile).build();
 
         if (vocabularyOnly) {
             owl2java.generateVocabulary(config);
@@ -143,6 +157,9 @@ public class OWL2JavaMojo extends AbstractMojo {
         Utils.logParameterValue(PREFER_MULTILINGUAL_STRINGS, preferMultilingualStrings, getLog());
         Utils.logParameterValue(GENERATE_ANNOTATION_FIELDS, generateAnnotationFields, getLog());
         Utils.logParameterValue(GENERATE_THING, generateThing, getLog());
+        Utils.logParameterValue(ONTOLOGY_PREFIX_PROPERTY, ontologyPrefixProperty, getLog());
+        Utils.logParameterValue(ALWAYS_USE_PREFIXES, alwaysUsePrefixes, getLog());
+        Utils.logParameterValue(PREFIX_MAPPING_FILE, prefixMappingFile, getLog());
     }
 
     public String getPackage() {

--- a/jopa-maven-plugin/src/main/java/cz/cvut/kbss/jopa/maven/OWL2JavaMojo.java
+++ b/jopa-maven-plugin/src/main/java/cz/cvut/kbss/jopa/maven/OWL2JavaMojo.java
@@ -91,7 +91,7 @@ public class OWL2JavaMojo extends AbstractMojo {
     @Parameter(name = ONTOLOGY_PREFIX_PROPERTY)
     private String ontologyPrefixProperty;
 
-    @Parameter(name = ALWAYS_USE_PREFIXES, defaultValue = "false")
+    @Parameter(name = ALWAYS_USE_PREFIXES, defaultValue = "true")
     private boolean alwaysUsePrefixes;
 
     @Parameter(name = PREFIX_MAPPING_FILE)

--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/Constants.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/Constants.java
@@ -17,6 +17,9 @@
  */
 package cz.cvut.kbss.jopa.owl2java;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
 public class Constants {
 
     /**
@@ -74,6 +77,11 @@ public class Constants {
      * Name of the field representing {@link cz.cvut.kbss.jopa.model.annotations.Properties}.
      */
     public static final String PROPERTIES_FIELD_NAME = "properties";
+
+    /**
+     * Timeout for resolving ontology prefix via a remote service.
+     */
+    public static final Duration PREFIX_RESOLVE_TIMEOUT = Duration.of(5, ChronoUnit.SECONDS);
 
     /**
      * Tool version.

--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/JavaNameGenerator.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/JavaNameGenerator.java
@@ -64,8 +64,8 @@ public class JavaNameGenerator {
         }
         assert ontologyId.getOntologyIRI().isPresent();
         final IRI ontologyIri = ontologyId.getOntologyIRI().get();
-        return prefixMap.getPrefix(ontologyIri)
-                        .orElse(generateJavaNameForIri(ontologyIri)) + SEPARATOR + generateJavaNameForIri(iri);
+        return makeNameValidJava(prefixMap.getPrefix(ontologyIri)
+                                          .orElse(generateJavaNameForIri(ontologyIri))) + SEPARATOR + generateJavaNameForIri(iri);
     }
 
     /**

--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/JavaNameGenerator.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/JavaNameGenerator.java
@@ -80,6 +80,16 @@ public class JavaNameGenerator {
     }
 
     /**
+     * Checks whether a prefix exists for the specified ontology identifier.
+     *
+     * @param ontologyIri Ontology IRI
+     * @return {@code true} if a prefix has been resolved for ontology IRI, {@code false} otherwise
+     */
+    public boolean hasPrefix(IRI ontologyIri) {
+        return prefixMap.hasPrefix(ontologyIri);
+    }
+
+    /**
      * Returns the specified name sanitized for Java.
      * <p>
      * This means the result of this function can be used as/in a Java variable/field/class name.

--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/JavaNameGenerator.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/JavaNameGenerator.java
@@ -1,5 +1,6 @@
 package cz.cvut.kbss.jopa.owl2java;
 
+import cz.cvut.kbss.jopa.owl2java.prefix.PrefixMap;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLOntologyID;
 

--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/JavaNameGenerator.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/JavaNameGenerator.java
@@ -1,0 +1,52 @@
+package cz.cvut.kbss.jopa.owl2java;
+
+import org.semanticweb.owlapi.model.IRI;
+
+import java.text.Normalizer;
+import java.util.Arrays;
+
+/**
+ * Generates Java names based on IRI identifiers.
+ */
+public class JavaNameGenerator {
+
+    private static final String[] JAVA_KEYWORDS = {"abstract", "assert", "boolean", "break", "byte", "case", "catch", "char", "class", "const", "continue", "default", "do", "double", "else", "enum", "extends", "final", "finally", "float", "for", "goto", "if", "implements", "import", "instanceof", "int", "interface", "long", "native", "new", "package", "private", "protected", "public", "return", "short", "static", "strictfp", "super", "switch", "synchronized", "this", "throw", "throws", "transient", "try", "void", "volatile", "while"};
+
+    public String generateJavaNameForIri(IRI iri) {
+        if (iri.getFragment() != null) {
+            return makeNameValidJava(iri.getFragment());
+        } else {
+            int x = iri.toString().lastIndexOf("/");
+            return makeNameValidJava(iri.toString().substring(x + 1));
+        }
+    }
+
+    private static String makeNameValidJava(final String name) {
+        String res = name.trim().replace("-", "_").replace("'", "_quote_")
+                      .replace(".", "_dot_").replace(',', '_');
+        // Replace non-ASCII characters with ASCII ones
+        res = Normalizer.normalize(res, Normalizer.Form.NFD).replaceAll("[^\\p{ASCII}]", "");
+        if (Arrays.binarySearch(JAVA_KEYWORDS, res) >= 0) {
+            res = "_" + res;
+        }
+        return res;
+    }
+
+    /**
+     * Converts the specified name to the Java camel case notation.
+     * <p>
+     * This process removes underscores used to generate the name.
+     *
+     * @param name Generated name
+     * @return Converted camel case name
+     */
+    public static String toCamelCaseNotation(String name) {
+        StringBuilder result = new StringBuilder();
+        for (String w : name.split("_")) {
+            if (!w.isEmpty()) {
+                result.append(w.substring(0, 1).toUpperCase()).append(w.substring(1));
+            }
+        }
+        return result.toString();
+    }
+}

--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/JavaNameGenerator.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/JavaNameGenerator.java
@@ -12,18 +12,40 @@ public class JavaNameGenerator {
 
     private static final String[] JAVA_KEYWORDS = {"abstract", "assert", "boolean", "break", "byte", "case", "catch", "char", "class", "const", "continue", "default", "do", "double", "else", "enum", "extends", "final", "finally", "float", "for", "goto", "if", "implements", "import", "instanceof", "int", "interface", "long", "native", "new", "package", "private", "protected", "public", "return", "short", "static", "strictfp", "super", "switch", "synchronized", "this", "throw", "throws", "transient", "try", "void", "volatile", "while"};
 
+    /**
+     * Returns a valid Java identifier extracted from the specified IRI.
+     * <p>
+     * If the IRI contains a non-empty fragment, it is used. Otherwise, the part after the last slash is used as the
+     * name.
+     *
+     * @param iri IRI to extract name from
+     * @return Java name based on the specified IRI
+     */
     public String generateJavaNameForIri(IRI iri) {
-        if (iri.getFragment() != null) {
+        if (iri.getFragment() != null && !iri.getFragment().isEmpty()) {
             return makeNameValidJava(iri.getFragment());
         } else {
-            int x = iri.toString().lastIndexOf("/");
-            return makeNameValidJava(iri.toString().substring(x + 1));
+            String strIri = iri.toString();
+            if (strIri.charAt(strIri.length() - 1) == '/') {
+                strIri = strIri.substring(0, strIri.length() - 1);
+            }
+            int x = strIri.lastIndexOf("/");
+            return makeNameValidJava(strIri.substring(x + 1));
         }
     }
 
-    private static String makeNameValidJava(final String name) {
+    /**
+     * Returns the specified name sanitized for Java.
+     * <p>
+     * This means the result of this function can be used as/in a Java variable/field/class name.
+     *
+     * @param name The name to sanitize
+     * @return Valid Java identifier
+     */
+    public static String makeNameValidJava(String name) {
         String res = name.trim().replace("-", "_").replace("'", "_quote_")
-                      .replace(".", "_dot_").replace(',', '_');
+                         .replace(".", "_dot_").replace(',', '_')
+                         .replace("#", "");
         // Replace non-ASCII characters with ASCII ones
         res = Normalizer.normalize(res, Normalizer.Form.NFD).replaceAll("[^\\p{ASCII}]", "");
         if (Arrays.binarySearch(JAVA_KEYWORDS, res) >= 0) {

--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/JavaTransformer.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/JavaTransformer.java
@@ -61,6 +61,7 @@ import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLDatatype;
 import org.semanticweb.owlapi.model.OWLEntity;
 import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyID;
 import org.semanticweb.owlapi.model.OWLOntologyManager;
 import org.semanticweb.owlapi.search.EntitySearcher;
 import org.slf4j.Logger;
@@ -517,7 +518,7 @@ public class JavaTransformer {
         String className = resolveExplicitClassName(rootOntology, owlClass)
                 .orElseGet(() -> JavaNameGenerator.toCamelCaseNotation(nameGenerator.generateJavaNameForIri(owlClass.getIRI())));
 
-        if (isClassNameUnique(pkg, className, codeModel) && !configuration.shouldAlwaysUseOntologyPrefix()) {
+        if (isClassNameUnique(pkg, className, codeModel) && !isPrefixedVersionRequired(onto.getOntologyID())) {
             return fqn(pkg, className);
         }
         className = JavaNameGenerator.toCamelCaseNotation(nameGenerator.generatePrefixedJavaNameForIri(owlClass.getIRI(), onto.getOntologyID()));
@@ -547,6 +548,11 @@ public class JavaTransformer {
 
     private static String fqn(String pkg, String simpleName) {
         return pkg + PACKAGE_SEPARATOR + simpleName;
+    }
+
+    private boolean isPrefixedVersionRequired(OWLOntologyID ontologyId) {
+        return configuration.shouldAlwaysUseOntologyPrefix()
+                && (ontologyId.isAnonymous() || nameGenerator.hasPrefix(ontologyId.getOntologyIRI().get()));
     }
 
     private void generateClassJavadoc(OWLOntology ontology, OWLEntity owlEntity, JDocCommentable javaElem) {

--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/JavaTransformer.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/JavaTransformer.java
@@ -231,7 +231,7 @@ public class JavaTransformer {
             return prefix;
         }
         String fieldName = PREFIX_STRING + prefix.get() + nameGenerator.generateJavaNameForIri(c.getIRI());
-        if (voc.fields().containsKey(fieldName)) {
+        if (voc.fields().containsKey(fieldName) || configuration.shouldAlwaysUseOntologyPrefix()) {
             final Optional<OWLOntology> containingOntology = resolveContainingOntology(c, ontologyManager);
             if (containingOntology.isPresent()) {
                 fieldName = PREFIX_STRING + prefix.get() + nameGenerator.generatePrefixedJavaNameForIri(c.getIRI(), containingOntology.get()
@@ -516,7 +516,7 @@ public class JavaTransformer {
         String className = resolveExplicitClassName(rootOntology, owlClass)
                 .orElseGet(() -> JavaNameGenerator.toCamelCaseNotation(nameGenerator.generateJavaNameForIri(owlClass.getIRI())));
 
-        if (isClassNameUnique(pkg, className, codeModel)) {
+        if (isClassNameUnique(pkg, className, codeModel) && !configuration.shouldAlwaysUseOntologyPrefix()) {
             return fqn(pkg, className);
         }
         className = JavaNameGenerator.toCamelCaseNotation(nameGenerator.generatePrefixedJavaNameForIri(owlClass.getIRI(), onto.getOntologyID()));

--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/JavaTransformer.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/JavaTransformer.java
@@ -219,9 +219,9 @@ public class JavaTransformer {
                                                       .sorted(Comparator.comparing(IRI::getIRIString))
                                                       .collect(Collectors.toList());
         ontologyIris.forEach(iri -> {
-            final String fieldName = ensureVocabularyItemUniqueIdentifier("ONTOLOGY_IRI_" + nameGenerator.getOntologyPrefix(iri)
-                                                                                                         .orElseGet(() -> nameGenerator.generateJavaNameForIri(iri))
-                                                                                                         .toUpperCase());
+            final String fieldName = ensureVocabularyItemUniqueIdentifier("ONTOLOGY_IRI_" + JavaNameGenerator.makeNameValidJava(nameGenerator.getOntologyPrefix(iri)
+                                                                                                                                             .orElseGet(() -> nameGenerator.generateJavaNameForIri(iri)))
+                                                                                                             .toUpperCase());
             voc.field(JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, fieldName, JExpr.lit(iri.toString()));
         });
     }

--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/JavaTransformer.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/JavaTransformer.java
@@ -51,6 +51,7 @@ import cz.cvut.kbss.jopa.owl2java.cli.Option;
 import cz.cvut.kbss.jopa.owl2java.cli.PropertiesType;
 import cz.cvut.kbss.jopa.owl2java.config.TransformationConfiguration;
 import cz.cvut.kbss.jopa.owl2java.exception.OWL2JavaException;
+import cz.cvut.kbss.jopa.owl2java.prefix.PrefixMap;
 import cz.cvut.kbss.jopa.owlapi.DatatypeTransformer;
 import cz.cvut.kbss.jopa.vocabulary.DC;
 import cz.cvut.kbss.jopa.vocabulary.RDFS;

--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/OWL2Java.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/OWL2Java.java
@@ -142,7 +142,7 @@ public class OWL2Java {
     }
 
     private static void transformOwlToJava(CliParams input) {
-        boolean whole = input.is(Option.WHOLE_ONTOLOGY_AS_IC.arg);
+        boolean whole = input.is(Option.WHOLE_ONTOLOGY_AS_IC.arg, Defaults.WHOLE_ONTOLOGY_AS_IC);
 
         if (!whole && invalidTransformationOptions(input)) {
             return;
@@ -169,7 +169,7 @@ public class OWL2Java {
     }
 
     private static void generateVocabulary(CliParams input) {
-        final boolean whole = input.is(Option.WHOLE_ONTOLOGY_AS_IC.arg);
+        final boolean whole = input.is(Option.WHOLE_ONTOLOGY_AS_IC.arg, Defaults.WHOLE_ONTOLOGY_AS_IC);
         if (!whole && invalidTransformationOptions(input)) {
             return;
         }

--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/OWL2JavaTransformer.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/OWL2JavaTransformer.java
@@ -86,7 +86,7 @@ public class OWL2JavaTransformer {
 
         try {
             m.loadOntology(IRI.create(owlOntologyName));
-            return new OWLOntologyMerger(m).createMergedOntology(m, IRI.create(owlOntologyName + "-generated"));
+            return new OWLOntologyMerger(m).createMergedOntology(m, null);
         } catch (OWLException | OWLRuntimeException e) {
             LOG.error(e.getMessage(), e);
             throw new OWL2JavaException("Unable to load ontology " + owlOntologyName, e);

--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/PrefixMap.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/PrefixMap.java
@@ -1,0 +1,104 @@
+package cz.cvut.kbss.jopa.owl2java;
+
+import cz.cvut.kbss.jopa.owl2java.config.TransformationConfiguration;
+import cz.cvut.kbss.jopa.vocabulary.DC;
+import cz.cvut.kbss.jopa.vocabulary.OWL;
+import cz.cvut.kbss.jopa.vocabulary.RDF;
+import cz.cvut.kbss.jopa.vocabulary.RDFS;
+import cz.cvut.kbss.jopa.vocabulary.SKOS;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLAnnotationAssertionAxiom;
+import org.semanticweb.owlapi.model.OWLAnnotationProperty;
+import org.semanticweb.owlapi.model.OWLDataFactory;
+import org.semanticweb.owlapi.model.OWLDataProperty;
+import org.semanticweb.owlapi.model.OWLLiteral;
+import org.semanticweb.owlapi.model.OWLNamedIndividual;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.semanticweb.owlapi.search.EntitySearcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Keeps a map of prefixes resolved from provided ontologies.
+ * <p>
+ * Prefixes are resolved using the following strategy:
+ * <ul>
+ *     <li>If an ontology has an explicitly specified prefix (using the configured prefix property), it is used</li>
+ *     <li></li>
+ * </ul>
+ */
+public class PrefixMap {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PrefixMap.class);
+
+    /**
+     * Map ontology IRI -> prefix
+     */
+    private final Map<String, String> prefixes;
+
+    public PrefixMap(OWLOntologyManager ontologyManager, TransformationConfiguration config) {
+        this.prefixes = resolvePrefixes(Objects.requireNonNull(ontologyManager), config.getOntologyPrefixProperty());
+    }
+
+    /**
+     * Resolves prefixes of ontologies accessible from the specified ontology manager.
+     *
+     * @param ontologyManager Manager of ontologies to process
+     */
+    private Map<String, String> resolvePrefixes(OWLOntologyManager ontologyManager, String prefixProperty) {
+        final Map<String, String> result = new HashMap<>(defaultPrefixes());
+        ontologyManager.ontologies().filter(o -> o.getOntologyID().isNamed()).forEach(o -> {
+            assert o.getOntologyID().getOntologyIRI().isPresent();
+            resolveOntologyPrefix(o, prefixProperty).ifPresent(prefix -> result.put(o.getOntologyID().getOntologyIRI()
+                                                                                     .get().getIRIString(), prefix));
+        });
+        LOG.debug("Resolved prefix map: {}", result);
+        return result;
+    }
+
+    private Optional<String> resolveOntologyPrefix(OWLOntology ontology, String prefixProperty) {
+        final OWLDataFactory df = ontology.getOWLOntologyManager().getOWLDataFactory();
+        final OWLAnnotationProperty annProperty = df.getOWLAnnotationProperty(prefixProperty);
+        assert ontology.getOntologyID().getOntologyIRI().isPresent();
+        final IRI ontologyIri = ontology.getOntologyID().getOntologyIRI().get();
+        final Optional<OWLAnnotationAssertionAxiom> prefixAnnotation = EntitySearcher.getAnnotationAssertionAxioms(ontologyIri, ontology)
+                                                                                     .filter(ann -> annProperty.equals(ann.getProperty()))
+                                                                                     .filter(ax -> ax.getValue()
+                                                                                                     .isLiteral())
+                                                                                     .findFirst();
+        if (prefixAnnotation.isPresent()) {
+            return prefixAnnotation.flatMap(a -> a.getValue().asLiteral()).map(OWLLiteral::getLiteral);
+        }
+        final OWLDataProperty dataProperty = df.getOWLDataProperty(prefixProperty);
+        final OWLNamedIndividual individual = df.getOWLNamedIndividual(ontologyIri);
+        return EntitySearcher.getDataPropertyValues(individual, dataProperty, ontology).findFirst().map(OWLLiteral::getLiteral);
+    }
+
+    /**
+     * Gets prefix for an ontology with the specified IRI.
+     *
+     * @param ontologyIri Ontology IRI
+     * @return Resolved prefix, if available
+     */
+    public Optional<String> getPrefix(IRI ontologyIri) {
+        Objects.requireNonNull(ontologyIri);
+        return Optional.ofNullable(prefixes.get(ontologyIri.getIRIString()));
+    }
+
+    private static Map<String, String> defaultPrefixes() {
+        return Map.of(
+                RDF.NAMESPACE, RDF.PREFIX,
+                RDFS.NAMESPACE, RDFS.PREFIX,
+                OWL.NAMESPACE, OWL.PREFIX,
+                SKOS.NAMESPACE, SKOS.PREFIX,
+                DC.Terms.NAMESPACE, "dcterms",
+                "http://xmlns.com/foaf/0.1/", "foaf"
+        );
+    }
+}

--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/cli/CommandParserProvider.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/cli/CommandParserProvider.java
@@ -56,6 +56,7 @@ public final class CommandParserProvider {
         p.accepts(WHOLE_ONTOLOGY_AS_IC).withOptionalArg().ofType(Boolean.class).defaultsTo(true);
         p.accepts(IGNORE_FAILED_IMPORTS).withOptionalArg().ofType(Boolean.class).defaultsTo(true);
         p.accepts(GENERATE_JAVADOC_FROM_COMMENT).withOptionalArg().ofType(Boolean.class).defaultsTo(true);
+        p.accepts(ONTOLOGY_PREFIX_PROPERTY).withOptionalArg().ofType(String.class).defaultsTo(Defaults.ONTOLOGY_PREFIX_PROPERTY);
         return p;
     }
 

--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/cli/Option.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/cli/Option.java
@@ -117,7 +117,12 @@ public enum Option {
     /**
      * Specifies whether to always use ontology prefix (if available) when generating vocabulary and model.
      */
-    ALWAYS_USE_ONTOLOGY_PREFIX("usePrefixes", "whether to always use ontology prefix for generating vocabulary and model");
+    ALWAYS_USE_ONTOLOGY_PREFIX("usePrefixes", "whether to always use ontology prefix for generating vocabulary and model"),
+
+    /**
+     * Specifies file containing ontology prefix mapping.
+     */
+    PREFIX_MAPPING_FILE("prefixFile", "file containing prefix mapping");
 
     public final String arg;
     final String description;

--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/cli/Option.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/cli/Option.java
@@ -99,14 +99,20 @@ public enum Option {
     GENERATE_JAVADOC_FROM_COMMENT("doc", "generate Javadoc from rdfs:comment annotations"),
 
     /**
-     * Whether to automatically generate name ({@literal rdfs:label}) and description ({@literal dc:description}) fields.
+     * Whether to automatically generate name ({@literal rdfs:label}) and description ({@literal dc:description})
+     * fields.
      */
     GENERATE_ANNOTATION_FIELDS("ann", "automatically generate rdfs:label and dc:description attributes for all entities"),
 
     /**
      * Whether to automatically generate an entity class corresponding to {@literal owl:Thing}.
      */
-    GENERATE_THING("thing", "automatically generate an entity class corresponding to owl:Thing");
+    GENERATE_THING("thing", "automatically generate an entity class corresponding to owl:Thing"),
+
+    /**
+     * Property whose value represents the ontology IRI prefix.
+     */
+    ONTOLOGY_PREFIX_PROPERTY("prefixProperty", "identifier of the property whose value represents the ontology IRI prefix");
 
     public final String arg;
     final String description;

--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/cli/Option.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/cli/Option.java
@@ -112,7 +112,12 @@ public enum Option {
     /**
      * Property whose value represents the ontology IRI prefix.
      */
-    ONTOLOGY_PREFIX_PROPERTY("prefixProperty", "identifier of the property whose value represents the ontology IRI prefix");
+    ONTOLOGY_PREFIX_PROPERTY("prefixProperty", "identifier of the property whose value represents the ontology IRI prefix"),
+
+    /**
+     * Specifies whether to always use ontology prefix (if available) when generating vocabulary and model.
+     */
+    ALWAYS_USE_ONTOLOGY_PREFIX("usePrefixes", "whether to always use ontology prefix for generating vocabulary and model");
 
     public final String arg;
     final String description;

--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/config/Defaults.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/config/Defaults.java
@@ -86,6 +86,11 @@ public class Defaults {
      */
     public static final String ONTOLOGY_PREFIX_PROPERTY = "http://purl.org/vocab/vann/preferredNamespacePrefix";
 
+    /**
+     * @see Option#ALWAYS_USE_ONTOLOGY_PREFIX
+     */
+    public static final boolean USE_ONTOLOGY_PREFIX = false;
+
     private Defaults() {
         throw new AssertionError();
     }

--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/config/Defaults.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/config/Defaults.java
@@ -81,6 +81,11 @@ public class Defaults {
      */
     public static final boolean GENERATE_THING = true;
 
+    /**
+     * @see Option#ONTOLOGY_PREFIX_PROPERTY
+     */
+    public static final String ONTOLOGY_PREFIX_PROPERTY = "http://purl.org/vocab/vann/preferredNamespacePrefix";
+
     private Defaults() {
         throw new AssertionError();
     }

--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/config/Defaults.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/config/Defaults.java
@@ -89,7 +89,7 @@ public class Defaults {
     /**
      * @see Option#ALWAYS_USE_ONTOLOGY_PREFIX
      */
-    public static final boolean USE_ONTOLOGY_PREFIX = false;
+    public static final boolean ALWAYS_USE_ONTOLOGY_PREFIX = true;
 
     private Defaults() {
         throw new AssertionError();

--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/config/TransformationConfiguration.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/config/TransformationConfiguration.java
@@ -20,6 +20,8 @@ package cz.cvut.kbss.jopa.owl2java.config;
 import cz.cvut.kbss.jopa.owl2java.cli.CliParams;
 import cz.cvut.kbss.jopa.owl2java.cli.Option;
 import cz.cvut.kbss.jopa.owl2java.cli.PropertiesType;
+import cz.cvut.kbss.jopa.owl2java.prefix.PrefixCcRemotePrefixResolver;
+import cz.cvut.kbss.jopa.owl2java.prefix.RemotePrefixResolver;
 
 public class TransformationConfiguration {
 
@@ -49,6 +51,8 @@ public class TransformationConfiguration {
 
     private final CliParams cliParams;
 
+    private final RemotePrefixResolver remotePrefixResolver;
+
     private TransformationConfiguration(TransformationConfigurationBuilder builder) {
         this.context = builder.context;
         this.packageName = builder.packageName;
@@ -62,6 +66,7 @@ public class TransformationConfiguration {
         this.ontologyPrefixProperty = builder.ontologyPrefixProperty;
         this.alwaysUseOntologyPrefix = builder.alwaysUseOntologyPrefix;
         this.prefixMappingFile = builder.prefixMappingFile;
+        this.remotePrefixResolver = builder.remotePrefixResolver;
         this.cliParams = CliParams.empty();
     }
 
@@ -82,6 +87,7 @@ public class TransformationConfiguration {
         this.alwaysUseOntologyPrefix = cliParams.is(Option.ALWAYS_USE_ONTOLOGY_PREFIX.arg, Defaults.USE_ONTOLOGY_PREFIX);
         this.prefixMappingFile = cliParams.has(Option.PREFIX_MAPPING_FILE.arg) ? cliParams.valueOf(Option.PREFIX_MAPPING_FILE.arg)
                                                                                           .toString() : null;
+        this.remotePrefixResolver = new PrefixCcRemotePrefixResolver();
     }
 
     public String getContext() {
@@ -136,6 +142,10 @@ public class TransformationConfiguration {
         return prefixMappingFile;
     }
 
+    public RemotePrefixResolver getRemotePrefixResolver() {
+        return remotePrefixResolver;
+    }
+
     public CliParams getCliParams() {
         return cliParams;
     }
@@ -161,6 +171,7 @@ public class TransformationConfiguration {
         private String ontologyPrefixProperty = Defaults.ONTOLOGY_PREFIX_PROPERTY;
         private boolean alwaysUseOntologyPrefix = Defaults.USE_ONTOLOGY_PREFIX;
         private String prefixMappingFile = null;
+        private RemotePrefixResolver remotePrefixResolver = new PrefixCcRemotePrefixResolver();
 
         public TransformationConfigurationBuilder context(String context) {
             this.context = context;
@@ -221,6 +232,11 @@ public class TransformationConfiguration {
 
         public TransformationConfigurationBuilder prefixMappingFile(String prefixMappingFile) {
             this.prefixMappingFile = prefixMappingFile;
+            return this;
+        }
+
+        public TransformationConfigurationBuilder remotePrefixResolver(RemotePrefixResolver resolver) {
+            this.remotePrefixResolver = resolver;
             return this;
         }
 

--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/config/TransformationConfiguration.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/config/TransformationConfiguration.java
@@ -77,7 +77,8 @@ public class TransformationConfiguration {
         this.propertiesType = PropertiesType.fromParam(cliParams.valueOf(Option.PROPERTIES_TYPE.arg));
         this.generateAnnotationFields = cliParams.is(Option.GENERATE_ANNOTATION_FIELDS.arg, Defaults.GENERATE_ANNOTATION_FIELDS);
         this.generateThing = cliParams.is(Option.GENERATE_THING.arg, Defaults.GENERATE_THING);
-        this.ontologyPrefixProperty = cliParams.valueOf(Option.ONTOLOGY_PREFIX_PROPERTY.arg).toString();
+        this.ontologyPrefixProperty = cliParams.has(Option.ONTOLOGY_PREFIX_PROPERTY.arg) ? cliParams.valueOf(Option.ONTOLOGY_PREFIX_PROPERTY.arg)
+                                                                                                    .toString() : Defaults.ONTOLOGY_PREFIX_PROPERTY;
         this.alwaysUseOntologyPrefix = cliParams.is(Option.ALWAYS_USE_ONTOLOGY_PREFIX.arg, Defaults.USE_ONTOLOGY_PREFIX);
         this.prefixMappingFile = cliParams.has(Option.PREFIX_MAPPING_FILE.arg) ? cliParams.valueOf(Option.PREFIX_MAPPING_FILE.arg)
                                                                                           .toString() : null;
@@ -207,7 +208,9 @@ public class TransformationConfiguration {
         }
 
         public TransformationConfigurationBuilder ontologyPrefixProperty(String ontologyPrefixProperty) {
-            this.ontologyPrefixProperty = ontologyPrefixProperty;
+            if (ontologyPrefixProperty != null && !ontologyPrefixProperty.isBlank()) {
+                this.ontologyPrefixProperty = ontologyPrefixProperty;
+            }
             return this;
         }
 

--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/config/TransformationConfiguration.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/config/TransformationConfiguration.java
@@ -41,6 +41,8 @@ public class TransformationConfiguration {
 
     private final boolean generateThing;
 
+    private final String ontologyPrefixProperty;
+
     private final CliParams cliParams;
 
     private TransformationConfiguration(TransformationConfigurationBuilder builder) {
@@ -53,6 +55,7 @@ public class TransformationConfiguration {
         this.propertiesType = builder.propertiesType;
         this.generateAnnotationFields = builder.generateAnnotationFields;
         this.generateThing = builder.generateThing;
+        this.ontologyPrefixProperty = builder.ontologyPrefixProperty;
         this.cliParams = CliParams.empty();
     }
 
@@ -68,6 +71,7 @@ public class TransformationConfiguration {
         this.propertiesType = PropertiesType.fromParam(cliParams.valueOf(Option.PROPERTIES_TYPE.arg));
         this.generateAnnotationFields = cliParams.is(Option.GENERATE_ANNOTATION_FIELDS.arg, Defaults.GENERATE_ANNOTATION_FIELDS);
         this.generateThing = cliParams.is(Option.GENERATE_THING.arg, Defaults.GENERATE_THING);
+        this.ontologyPrefixProperty = cliParams.valueOf(Option.ONTOLOGY_PREFIX_PROPERTY.arg).toString();
     }
 
     public String getContext() {
@@ -110,6 +114,10 @@ public class TransformationConfiguration {
         return generateThing;
     }
 
+    public String getOntologyPrefixProperty() {
+        return ontologyPrefixProperty;
+    }
+
     public CliParams getCliParams() {
         return cliParams;
     }
@@ -132,6 +140,7 @@ public class TransformationConfiguration {
         private boolean preferMultilingualStrings = Defaults.PREFER_MULTILINGUAL_STRINGS;
         private boolean generateAnnotationFields = Defaults.GENERATE_ANNOTATION_FIELDS;
         private boolean generateThing = Defaults.GENERATE_THING;
+        private String ontologyPrefixProperty = Defaults.ONTOLOGY_PREFIX_PROPERTY;
 
         public TransformationConfigurationBuilder context(String context) {
             this.context = context;
@@ -175,6 +184,11 @@ public class TransformationConfiguration {
 
         public TransformationConfigurationBuilder generateThing(boolean generateThing) {
             this.generateThing = generateThing;
+            return this;
+        }
+
+        public TransformationConfigurationBuilder ontologyPrefixProperty(String ontologyPrefixProperty) {
+            this.ontologyPrefixProperty = ontologyPrefixProperty;
             return this;
         }
 

--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/config/TransformationConfiguration.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/config/TransformationConfiguration.java
@@ -43,6 +43,8 @@ public class TransformationConfiguration {
 
     private final String ontologyPrefixProperty;
 
+    private final boolean alwaysUseOntologyPrefix;
+
     private final CliParams cliParams;
 
     private TransformationConfiguration(TransformationConfigurationBuilder builder) {
@@ -56,6 +58,7 @@ public class TransformationConfiguration {
         this.generateAnnotationFields = builder.generateAnnotationFields;
         this.generateThing = builder.generateThing;
         this.ontologyPrefixProperty = builder.ontologyPrefixProperty;
+        this.alwaysUseOntologyPrefix = builder.alwaysUseOntologyPrefix;
         this.cliParams = CliParams.empty();
     }
 
@@ -72,6 +75,7 @@ public class TransformationConfiguration {
         this.generateAnnotationFields = cliParams.is(Option.GENERATE_ANNOTATION_FIELDS.arg, Defaults.GENERATE_ANNOTATION_FIELDS);
         this.generateThing = cliParams.is(Option.GENERATE_THING.arg, Defaults.GENERATE_THING);
         this.ontologyPrefixProperty = cliParams.valueOf(Option.ONTOLOGY_PREFIX_PROPERTY.arg).toString();
+        this.alwaysUseOntologyPrefix = cliParams.is(Option.ALWAYS_USE_ONTOLOGY_PREFIX.arg, Defaults.USE_ONTOLOGY_PREFIX);
     }
 
     public String getContext() {
@@ -118,6 +122,10 @@ public class TransformationConfiguration {
         return ontologyPrefixProperty;
     }
 
+    public boolean shouldAlwaysUseOntologyPrefix() {
+        return alwaysUseOntologyPrefix;
+    }
+
     public CliParams getCliParams() {
         return cliParams;
     }
@@ -141,6 +149,7 @@ public class TransformationConfiguration {
         private boolean generateAnnotationFields = Defaults.GENERATE_ANNOTATION_FIELDS;
         private boolean generateThing = Defaults.GENERATE_THING;
         private String ontologyPrefixProperty = Defaults.ONTOLOGY_PREFIX_PROPERTY;
+        private boolean alwaysUseOntologyPrefix = Defaults.USE_ONTOLOGY_PREFIX;
 
         public TransformationConfigurationBuilder context(String context) {
             this.context = context;
@@ -189,6 +198,11 @@ public class TransformationConfiguration {
 
         public TransformationConfigurationBuilder ontologyPrefixProperty(String ontologyPrefixProperty) {
             this.ontologyPrefixProperty = ontologyPrefixProperty;
+            return this;
+        }
+
+        public TransformationConfigurationBuilder alwaysUseOntologyPrefix(boolean alwaysUseOntologyPrefix) {
+            this.alwaysUseOntologyPrefix = alwaysUseOntologyPrefix;
             return this;
         }
 

--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/config/TransformationConfiguration.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/config/TransformationConfiguration.java
@@ -45,6 +45,8 @@ public class TransformationConfiguration {
 
     private final boolean alwaysUseOntologyPrefix;
 
+    private final String prefixMappingFile;
+
     private final CliParams cliParams;
 
     private TransformationConfiguration(TransformationConfigurationBuilder builder) {
@@ -59,6 +61,7 @@ public class TransformationConfiguration {
         this.generateThing = builder.generateThing;
         this.ontologyPrefixProperty = builder.ontologyPrefixProperty;
         this.alwaysUseOntologyPrefix = builder.alwaysUseOntologyPrefix;
+        this.prefixMappingFile = builder.prefixMappingFile;
         this.cliParams = CliParams.empty();
     }
 
@@ -76,6 +79,8 @@ public class TransformationConfiguration {
         this.generateThing = cliParams.is(Option.GENERATE_THING.arg, Defaults.GENERATE_THING);
         this.ontologyPrefixProperty = cliParams.valueOf(Option.ONTOLOGY_PREFIX_PROPERTY.arg).toString();
         this.alwaysUseOntologyPrefix = cliParams.is(Option.ALWAYS_USE_ONTOLOGY_PREFIX.arg, Defaults.USE_ONTOLOGY_PREFIX);
+        this.prefixMappingFile = cliParams.has(Option.PREFIX_MAPPING_FILE.arg) ? cliParams.valueOf(Option.PREFIX_MAPPING_FILE.arg)
+                                                                                          .toString() : null;
     }
 
     public String getContext() {
@@ -126,6 +131,10 @@ public class TransformationConfiguration {
         return alwaysUseOntologyPrefix;
     }
 
+    public String getPrefixMappingFile() {
+        return prefixMappingFile;
+    }
+
     public CliParams getCliParams() {
         return cliParams;
     }
@@ -150,6 +159,7 @@ public class TransformationConfiguration {
         private boolean generateThing = Defaults.GENERATE_THING;
         private String ontologyPrefixProperty = Defaults.ONTOLOGY_PREFIX_PROPERTY;
         private boolean alwaysUseOntologyPrefix = Defaults.USE_ONTOLOGY_PREFIX;
+        private String prefixMappingFile = null;
 
         public TransformationConfigurationBuilder context(String context) {
             this.context = context;
@@ -203,6 +213,11 @@ public class TransformationConfiguration {
 
         public TransformationConfigurationBuilder alwaysUseOntologyPrefix(boolean alwaysUseOntologyPrefix) {
             this.alwaysUseOntologyPrefix = alwaysUseOntologyPrefix;
+            return this;
+        }
+
+        public TransformationConfigurationBuilder prefixMappingFile(String prefixMappingFile) {
+            this.prefixMappingFile = prefixMappingFile;
             return this;
         }
 

--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/config/TransformationConfiguration.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/config/TransformationConfiguration.java
@@ -84,7 +84,7 @@ public class TransformationConfiguration {
         this.generateThing = cliParams.is(Option.GENERATE_THING.arg, Defaults.GENERATE_THING);
         this.ontologyPrefixProperty = cliParams.has(Option.ONTOLOGY_PREFIX_PROPERTY.arg) ? cliParams.valueOf(Option.ONTOLOGY_PREFIX_PROPERTY.arg)
                                                                                                     .toString() : Defaults.ONTOLOGY_PREFIX_PROPERTY;
-        this.alwaysUseOntologyPrefix = cliParams.is(Option.ALWAYS_USE_ONTOLOGY_PREFIX.arg, Defaults.USE_ONTOLOGY_PREFIX);
+        this.alwaysUseOntologyPrefix = cliParams.is(Option.ALWAYS_USE_ONTOLOGY_PREFIX.arg, Defaults.ALWAYS_USE_ONTOLOGY_PREFIX);
         this.prefixMappingFile = cliParams.has(Option.PREFIX_MAPPING_FILE.arg) ? cliParams.valueOf(Option.PREFIX_MAPPING_FILE.arg)
                                                                                           .toString() : null;
         this.remotePrefixResolver = new PrefixCcRemotePrefixResolver();
@@ -169,7 +169,7 @@ public class TransformationConfiguration {
         private boolean generateAnnotationFields = Defaults.GENERATE_ANNOTATION_FIELDS;
         private boolean generateThing = Defaults.GENERATE_THING;
         private String ontologyPrefixProperty = Defaults.ONTOLOGY_PREFIX_PROPERTY;
-        private boolean alwaysUseOntologyPrefix = Defaults.USE_ONTOLOGY_PREFIX;
+        private boolean alwaysUseOntologyPrefix = Defaults.ALWAYS_USE_ONTOLOGY_PREFIX;
         private String prefixMappingFile = null;
         private RemotePrefixResolver remotePrefixResolver = new PrefixCcRemotePrefixResolver();
 

--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/prefix/PrefixCcRemotePrefixResolver.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/prefix/PrefixCcRemotePrefixResolver.java
@@ -1,0 +1,45 @@
+package cz.cvut.kbss.jopa.owl2java.prefix;
+
+import cz.cvut.kbss.jopa.owl2java.Constants;
+import org.semanticweb.owlapi.model.IRI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Optional;
+
+/**
+ * Resolves ontology prefixes using the <a href="https://prefix.cc">prefix.cc</a> service reverse lookup.
+ */
+public class PrefixCcRemotePrefixResolver implements RemotePrefixResolver {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PrefixCcRemotePrefixResolver.class);
+
+    private static final String URL = "https://prefix.cc/reverse?format=ini&uri=";
+
+    private final HttpClient client = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build();
+
+    @Override
+    public Optional<String> resolvePrefix(IRI ontologyIri) {
+        LOG.trace("Attempting to resolve prefix for IRI <{}> via prefix.cc", ontologyIri);
+        try {
+            final HttpRequest req = HttpRequest.newBuilder(URI.create(URL + ontologyIri.getIRIString())).GET()
+                                               .timeout(Constants.PREFIX_RESOLVE_TIMEOUT).build();
+            final HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+            if (resp.statusCode() != 200) {
+                LOG.debug("Prefix for ontology IRI <{}> not found.", ontologyIri);
+                return Optional.empty();
+            }
+            final String[] parts = resp.body().split("=");
+            assert parts.length == 2;
+            return Optional.of(parts[0]);
+        } catch (IOException | InterruptedException e) {
+            LOG.error("Unable to resolve prefix for ontology IRI <{}>.", ontologyIri, e);
+            return Optional.empty();
+        }
+    }
+}

--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/prefix/RemotePrefixResolver.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/prefix/RemotePrefixResolver.java
@@ -1,0 +1,19 @@
+package cz.cvut.kbss.jopa.owl2java.prefix;
+
+import org.semanticweb.owlapi.model.IRI;
+
+import java.util.Optional;
+
+/**
+ * Attempts to resolve ontology prefix by invoking a remote service.
+ */
+public interface RemotePrefixResolver {
+
+    /**
+     * Resolves prefix of an ontology with the specified IRI.
+     *
+     * @param ontologyIri IRI of the ontology to get prefix for
+     * @return Resolved prefix wrapped in {@code Optional}, empty {@code Optional} if unable to get the prefix
+     */
+    Optional<String> resolvePrefix(IRI ontologyIri);
+}

--- a/jopa-owl2java/src/test/java/cz/cvut/kbss/jopa/owl2java/JavaNameGeneratorTest.java
+++ b/jopa-owl2java/src/test/java/cz/cvut/kbss/jopa/owl2java/JavaNameGeneratorTest.java
@@ -1,0 +1,36 @@
+package cz.cvut.kbss.jopa.owl2java;
+
+import org.junit.jupiter.api.Test;
+import org.semanticweb.owlapi.model.IRI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JavaNameGeneratorTest {
+
+    private static final String PREFIX = "http://onto.fel.cvut.cz/ontologies/owl2java-test/";
+
+    private final JavaNameGenerator sut = new JavaNameGenerator();
+
+    @Test
+    void toCamelCaseNotationCamelCasesStringsSeparatedByUnderscore() {
+        assertEquals("TestValueCamelCased", JavaNameGenerator.toCamelCaseNotation("test_value_camel_cased"));
+    }
+
+    @Test
+    void generateJavaNameForIriGeneratesValidJavaIdentifiersForIriWithNonAsciiCharacters() {
+        final IRI iri = IRI.create(PREFIX + "navržený-pojem");
+        assertEquals("navrzeny_pojem", sut.generateJavaNameForIri(iri));
+    }
+
+    @Test
+    void generateJavaNameForIriSanitizesJavaKeywords() {
+        final IRI iri = IRI.create(PREFIX + "volatile");
+        assertEquals("_volatile", sut.generateJavaNameForIri(iri));
+    }
+
+    @Test
+    void generateJavaNameUsesFragmentWhenIriContainsIt() {
+        final IRI iri = IRI.create("http://onto.fel.cvut.cz/ontologies/owl2java-test#Fragment");
+        assertEquals("Fragment", sut.generateJavaNameForIri(iri));
+    }
+}

--- a/jopa-owl2java/src/test/java/cz/cvut/kbss/jopa/owl2java/JavaNameGeneratorTest.java
+++ b/jopa-owl2java/src/test/java/cz/cvut/kbss/jopa/owl2java/JavaNameGeneratorTest.java
@@ -1,5 +1,6 @@
 package cz.cvut.kbss.jopa.owl2java;
 
+import cz.cvut.kbss.jopa.owl2java.prefix.PrefixMap;
 import cz.cvut.kbss.jopa.vocabulary.RDFS;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/jopa-owl2java/src/test/java/cz/cvut/kbss/jopa/owl2java/JavaNameGeneratorTest.java
+++ b/jopa-owl2java/src/test/java/cz/cvut/kbss/jopa/owl2java/JavaNameGeneratorTest.java
@@ -85,4 +85,12 @@ class JavaNameGeneratorTest {
         assertEquals("Event", sut.generatePrefixedJavaNameForIri(iri, new OWLOntologyID()));
         verify(prefixMap, never()).getPrefix(any());
     }
+
+    @Test
+    void generatedPrefixedJavaNameForIriReturnsValidJavaNameWhenPrefixContainsDashes() {
+        final IRI ontologyIri = IRI.create("http://onto.fel.cvut.cz/ontologies/slovn\\u00edk/agendov\\u00fd/popis-dat");
+        final IRI iri = IRI.create("http://onto.fel.cvut.cz/ontologies/slovn\\u00edk/agendov\\u00fd/popis-dat/pojem/atribut");
+        when(prefixMap.getPrefix(ontologyIri)).thenReturn(Optional.of("popis-dat"));
+        assertEquals("popis_dat_atribut", sut.generatePrefixedJavaNameForIri(iri, new OWLOntologyID(ontologyIri)));
+    }
 }

--- a/jopa-owl2java/src/test/java/cz/cvut/kbss/jopa/owl2java/JavaNameGeneratorTest.java
+++ b/jopa-owl2java/src/test/java/cz/cvut/kbss/jopa/owl2java/JavaNameGeneratorTest.java
@@ -29,8 +29,20 @@ class JavaNameGeneratorTest {
     }
 
     @Test
-    void generateJavaNameUsesFragmentWhenIriContainsIt() {
+    void generateJavaNameForIriUsesFragmentWhenIriContainsIt() {
         final IRI iri = IRI.create("http://onto.fel.cvut.cz/ontologies/owl2java-test#Fragment");
         assertEquals("Fragment", sut.generateJavaNameForIri(iri));
+    }
+
+    @Test
+    void generateJavaNameForIriUsesPartBetweenLastHashAndFragmentWhenFragmentIsLastChar() {
+        final IRI iri = IRI.create("http://www.w3.org/ns/activitystreams#");
+        assertEquals("activitystreams", sut.generateJavaNameForIri(iri));
+    }
+
+    @Test
+    void generateJavaNameForIriUsesPartBetweenLastAndSecondToLastSlashWhenSlashIsLastChar() {
+        final IRI iri = IRI.create("http://purl.org/vocab/vann/");
+        assertEquals("vann", sut.generateJavaNameForIri(iri));
     }
 }

--- a/jopa-owl2java/src/test/java/cz/cvut/kbss/jopa/owl2java/JavaTransformerTest.java
+++ b/jopa-owl2java/src/test/java/cz/cvut/kbss/jopa/owl2java/JavaTransformerTest.java
@@ -21,6 +21,7 @@ import com.sun.codemodel.JDefinedClass;
 import com.sun.codemodel.JFieldVar;
 import com.sun.codemodel.JType;
 import cz.cvut.kbss.jopa.model.MultilingualString;
+import cz.cvut.kbss.jopa.owl2java.config.Defaults;
 import cz.cvut.kbss.jopa.owl2java.config.TransformationConfiguration;
 import cz.cvut.kbss.jopa.vocabulary.RDFS;
 import cz.cvut.kbss.jopa.vocabulary.SKOS;
@@ -28,10 +29,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLAnnotationProperty;
 import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLDataFactory;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.semanticweb.owlapi.util.OWLOntologyMerger;
 import org.semanticweb.owlapi.vocab.OWL2Datatype;
 import uk.ac.manchester.cs.owl.owlapi.OWLDataFactoryImpl;
 
@@ -43,6 +46,7 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -54,7 +58,9 @@ import static org.junit.jupiter.api.Assertions.fail;
 class JavaTransformerTest {
 
     private static final String PREFIX = "http://onto.fel.cvut.cz/ontologies/jopa/";
-    private static final String ONTOLOGY_IRI = "http://onto.fel.cvut.cz/ontologies/owl2java/java-transformer-test";
+    private static final String ONTOLOGY_IRI = "http://onto.fel.cvut.cz/ontologies/owl2java/java-transformer-test/";
+
+    private OWLOntologyManager ontologyManager;
 
     private OWLOntology ontology;
 
@@ -64,8 +70,8 @@ class JavaTransformerTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        final OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
-        this.ontology = manager.createOntology(IRI.create(ONTOLOGY_IRI));
+        this.ontologyManager = OWLManager.createOWLOntologyManager();
+        this.ontology = ontologyManager.createOntology(IRI.create(ONTOLOGY_IRI));
         this.dataFactory = new OWLDataFactoryImpl();
         this.sut = new JavaTransformer(TransformationConfiguration.builder().packageName("").build());
     }
@@ -287,5 +293,47 @@ class JavaTransformerTest {
         }
         assertEquals(2, classes.size());
         assertEquals(2, classes.stream().filter(cls -> cls.name().startsWith(className)).count());
+    }
+
+    @Test
+    void generateVocabularyDisambiguatePropertiesWithSameNameUsingPrefix() throws Exception {
+        final OWLAnnotationProperty prefixProperty = dataFactory.getOWLAnnotationProperty(Defaults.ONTOLOGY_PREFIX_PROPERTY);
+        ontology.add(dataFactory.getOWLAnnotationAssertionAxiom(prefixProperty, IRI.create(ONTOLOGY_IRI), dataFactory.getOWLLiteral("test")));
+        final IRI personIri = IRI.create(PREFIX + "Person");
+        ontology.add(dataFactory.getOWLDeclarationAxiom(dataFactory.getOWLClass(personIri)));
+        final ContextDefinition context = new ContextDefinition();
+        context.add(dataFactory.getOWLClass(personIri));
+        final IRI foafOntIri = IRI.create("http://xmlns.com/foaf/0.1/");
+        final OWLOntology foafOnto = ontology.getOWLOntologyManager().createOntology(foafOntIri);
+        foafOnto.add(dataFactory.getOWLAnnotationAssertionAxiom(prefixProperty, foafOntIri, dataFactory.getOWLLiteral("foaf")));
+        final IRI foafPersonIri = IRI.create(foafOntIri.getIRIString() + "Person");
+        foafOnto.add(dataFactory.getOWLDeclarationAxiom(dataFactory.getOWLClass(foafPersonIri)));
+        context.add(dataFactory.getOWLClass(foafPersonIri));
+        final OWLOntology merged = new OWLOntologyMerger(ontologyManager).createMergedOntology(ontologyManager, null);
+
+        final ObjectModel result = sut.generateVocabulary(merged, context);
+        final JDefinedClass vocabClass = result.getCodeModel()._getClass(Constants.VOCABULARY_CLASS);
+        assertNotNull(vocabClass);
+        final Map<String, JFieldVar> fields = vocabClass.fields();
+        assertThat(fields.keySet(), hasItem("s_c_Person"));
+        assertThat(fields.keySet(), hasItem("s_c_foaf_Person"));
+    }
+
+    @Test
+    void generateVocabularyUsesOntologyPrefixesInFieldNamesWhenGeneratingOntologyIriConstants() throws Exception {
+        final ContextDefinition context = new ContextDefinition();
+        final OWLAnnotationProperty prefixProperty = dataFactory.getOWLAnnotationProperty(Defaults.ONTOLOGY_PREFIX_PROPERTY);
+        ontology.add(dataFactory.getOWLAnnotationAssertionAxiom(prefixProperty, IRI.create(ONTOLOGY_IRI), dataFactory.getOWLLiteral("test")));
+        final IRI foafOntIri = IRI.create("http://xmlns.com/foaf/0.1/");
+        final OWLOntology foafOnto = ontology.getOWLOntologyManager().createOntology(foafOntIri);
+        foafOnto.add(dataFactory.getOWLAnnotationAssertionAxiom(prefixProperty, foafOntIri, dataFactory.getOWLLiteral("foaf")));
+        final OWLOntology merged = new OWLOntologyMerger(ontologyManager).createMergedOntology(ontologyManager, null);
+
+        final ObjectModel result = sut.generateVocabulary(merged, context);
+        final JDefinedClass vocabClass = result.getCodeModel()._getClass(Constants.VOCABULARY_CLASS);
+        assertNotNull(vocabClass);
+        final Map<String, JFieldVar> fields = vocabClass.fields();
+        assertThat(fields.keySet(), hasItem("ONTOLOGY_IRI_TEST"));
+        assertThat(fields.keySet(), hasItem("ONTOLOGY_IRI_FOAF"));
     }
 }

--- a/jopa-owl2java/src/test/java/cz/cvut/kbss/jopa/owl2java/JavaTransformerTest.java
+++ b/jopa-owl2java/src/test/java/cz/cvut/kbss/jopa/owl2java/JavaTransformerTest.java
@@ -73,7 +73,8 @@ class JavaTransformerTest {
         this.ontologyManager = OWLManager.createOWLOntologyManager();
         this.ontology = ontologyManager.createOntology(IRI.create(ONTOLOGY_IRI));
         this.dataFactory = new OWLDataFactoryImpl();
-        this.sut = new JavaTransformer(TransformationConfiguration.builder().packageName("").build());
+        this.sut = new JavaTransformer(TransformationConfiguration.builder().packageName("")
+                                                                  .alwaysUseOntologyPrefix(false).build());
     }
 
     @Test
@@ -193,6 +194,7 @@ class JavaTransformerTest {
     @Test
     void generateModelGeneratesFieldOfTypeStringForLangStringRangeWhenConfiguredNotToPreferMultilingualStrings() {
         this.sut = new JavaTransformer(TransformationConfiguration.builder().preferMultilingualStrings(false)
+                                                                  .alwaysUseOntologyPrefix(false)
                                                                   .packageName("").build());
         final String className = "TestClass";
         final String fieldName = "multilingualString";
@@ -244,6 +246,7 @@ class JavaTransformerTest {
     @Test
     void generateModelDoesNotGenerateLabelAndDescriptionFieldsWhenDisabled() {
         this.sut = new JavaTransformer(TransformationConfiguration.builder().packageName("")
+                                                                  .alwaysUseOntologyPrefix(false)
                                                                   .generateAnnotationFields(false).build());
         final String className = "TestClass";
         final IRI iri = IRI.create(PREFIX + className);
@@ -275,7 +278,7 @@ class JavaTransformerTest {
     @Test
     void generateModelDisambiguateClassesWithIdenticalJavaName() {
         this.sut = new JavaTransformer(TransformationConfiguration.builder().packageName("").generateThing(false)
-                                                                  .build());
+                                                                  .alwaysUseOntologyPrefix(false).build());
         final String className = "Concept";
         final IRI iriOne = IRI.create(PREFIX + className);
         final IRI iriTwo = IRI.create(SKOS.CONCEPT);

--- a/jopa-owl2java/src/test/java/cz/cvut/kbss/jopa/owl2java/OWL2JavaTest.java
+++ b/jopa-owl2java/src/test/java/cz/cvut/kbss/jopa/owl2java/OWL2JavaTest.java
@@ -49,7 +49,7 @@ public class OWL2JavaTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        this.mappingFilePath = TestUtils.resolveMappingFilePath();
+        this.mappingFilePath = TestUtils.resolveTestResourcesFilePath(TestUtils.MAPPING_FILE_NAME);
         System.setOut(new PrintStream(outContent));
         System.setErr(new PrintStream(errContent));
     }

--- a/jopa-owl2java/src/test/java/cz/cvut/kbss/jopa/owl2java/OWL2JavaTransformerTest.java
+++ b/jopa-owl2java/src/test/java/cz/cvut/kbss/jopa/owl2java/OWL2JavaTransformerTest.java
@@ -347,8 +347,8 @@ public class OWL2JavaTransformerTest {
         transformer.generateVocabulary(config(null, "", targetDir.getAbsolutePath(), true).build());
         final File vocabularyFile = targetDir.listFiles()[0];
         final String fileContents = readFile(vocabularyFile);
-        assertTrue(fileContents.contains("ONTOLOGY_IRI_model"));
-        assertTrue(fileContents.contains("ONTOLOGY_IRI_model_A"));
+        assertTrue(fileContents.contains("ONTOLOGY_IRI_MODEL"));
+        assertTrue(fileContents.contains("ONTOLOGY_IRI_MODEL_A"));
     }
 
     @Test

--- a/jopa-owl2java/src/test/java/cz/cvut/kbss/jopa/owl2java/OWL2JavaTransformerTest.java
+++ b/jopa-owl2java/src/test/java/cz/cvut/kbss/jopa/owl2java/OWL2JavaTransformerTest.java
@@ -76,7 +76,7 @@ public class OWL2JavaTransformerTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        this.mappingFilePath = TestUtils.resolveMappingFilePath();
+        this.mappingFilePath = TestUtils.resolveTestResourcesFilePath(TestUtils.MAPPING_FILE_NAME);
         this.dataFactory = new OWLDataFactoryImpl();
         this.transformer = new OWL2JavaTransformer();
     }

--- a/jopa-owl2java/src/test/java/cz/cvut/kbss/jopa/owl2java/PrefixMapTest.java
+++ b/jopa-owl2java/src/test/java/cz/cvut/kbss/jopa/owl2java/PrefixMapTest.java
@@ -1,0 +1,114 @@
+package cz.cvut.kbss.jopa.owl2java;
+
+import cz.cvut.kbss.jopa.owl2java.config.Defaults;
+import cz.cvut.kbss.jopa.owl2java.config.TransformationConfiguration;
+import cz.cvut.kbss.jopa.owl2java.environment.Generator;
+import cz.cvut.kbss.jopa.vocabulary.DC;
+import cz.cvut.kbss.jopa.vocabulary.OWL;
+import cz.cvut.kbss.jopa.vocabulary.RDF;
+import cz.cvut.kbss.jopa.vocabulary.RDFS;
+import cz.cvut.kbss.jopa.vocabulary.SKOS;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLAnnotationProperty;
+import org.semanticweb.owlapi.model.OWLDataFactory;
+import org.semanticweb.owlapi.model.OWLDataProperty;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyCreationException;
+import org.semanticweb.owlapi.model.OWLOntologyManager;
+import uk.ac.manchester.cs.owl.owlapi.OWLDataFactoryImpl;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PrefixMapTest {
+
+    private final OWLDataFactory dataFactory = new OWLDataFactoryImpl();
+
+    private final OWLOntologyManager ontologyManager = OWLManager.createOWLOntologyManager();
+
+    @Test
+    void getPrefixReturnsPrefixResolvedFromSingleStringAnnotationPropertyValue() {
+        final TransformationConfiguration config = new TransformationConfiguration.TransformationConfigurationBuilder().build();
+        final String prefix = "owl2java";
+        final IRI ontologyIri = IRI.create(Generator.generateUri());
+        assertOntologyPrefixAnnotation(prefix, ontologyIri);
+        final PrefixMap sut = new PrefixMap(ontologyManager, config);
+        final Optional<String> result = sut.getPrefix(ontologyIri);
+        assertTrue(result.isPresent());
+        assertEquals(prefix, result.get());
+    }
+
+    @Test
+    void getPrefixReturnsPrefixResolvedFromSingleStringDataPropertyValue() throws Exception {
+        final TransformationConfiguration config = new TransformationConfiguration.TransformationConfigurationBuilder().build();
+        final String prefix = "owl2java";
+        final IRI ontologyIri = IRI.create(Generator.generateUri());
+        final OWLOntology ontology = ontologyManager.createOntology(ontologyIri);
+        final OWLDataProperty prefixProperty = dataFactory.getOWLDataProperty(Defaults.ONTOLOGY_PREFIX_PROPERTY);
+        ontology.add(dataFactory.getOWLDataPropertyAssertionAxiom(prefixProperty, dataFactory.getOWLNamedIndividual(ontologyIri), dataFactory.getOWLLiteral(prefix)));
+        final PrefixMap sut = new PrefixMap(ontologyManager, config);
+        final Optional<String> result = sut.getPrefix(ontologyIri);
+        assertTrue(result.isPresent());
+        assertEquals(prefix, result.get());
+    }
+
+    @Test
+    void getPrefixReturnsPrefixesOfMultipleOntologies() {
+        final TransformationConfiguration config = new TransformationConfiguration.TransformationConfigurationBuilder().build();
+        final Map<String, IRI> prefixes = Map.of(
+                "owl2java", IRI.create(Generator.generateUri()),
+                "jopa", IRI.create(Generator.generateUri())
+        );
+        prefixes.forEach(this::assertOntologyPrefixAnnotation);
+        final PrefixMap sut = new PrefixMap(ontologyManager, config);
+
+        prefixes.forEach((prefix, iri) -> {
+            final Optional<String> result = sut.getPrefix(iri);
+            assertTrue(result.isPresent());
+            assertEquals(prefix, result.get());
+        });
+    }
+
+    private void assertOntologyPrefixAnnotation(String prefix, IRI ontologyIri) {
+        try {
+            final OWLOntology ontology = ontologyManager.createOntology(ontologyIri);
+            final OWLAnnotationProperty prefixProperty = dataFactory.getOWLAnnotationProperty(Defaults.ONTOLOGY_PREFIX_PROPERTY);
+            ontology.add(dataFactory.getOWLAnnotationAssertionAxiom(prefixProperty, ontologyIri, dataFactory.getOWLLiteral(prefix)));
+        } catch (OWLOntologyCreationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("predefinedPrefixes")
+    void getPrefixReturnsPredefinedPrefixesForSelectedVocabularies(String expectedPrefix, IRI iri) {
+        final TransformationConfiguration config = new TransformationConfiguration.TransformationConfigurationBuilder().build();
+        final String prefix = "owl2java";
+        final IRI ontologyIri = IRI.create(Generator.generateUri());
+        assertOntologyPrefixAnnotation(prefix, ontologyIri);
+        final PrefixMap sut = new PrefixMap(ontologyManager, config);
+        final Optional<String> result = sut.getPrefix(iri);
+        assertTrue(result.isPresent());
+        assertEquals(expectedPrefix, result.get());
+    }
+
+    static Stream<Arguments> predefinedPrefixes() {
+        return Stream.of(
+                Arguments.of("dcterms", IRI.create(DC.Terms.NAMESPACE)),
+                Arguments.of(RDF.PREFIX, IRI.create(RDF.NAMESPACE)),
+                Arguments.of(RDFS.PREFIX, IRI.create(RDFS.NAMESPACE)),
+                Arguments.of(OWL.PREFIX, IRI.create(OWL.NAMESPACE)),
+                Arguments.of(SKOS.PREFIX, IRI.create(SKOS.NAMESPACE)),
+                Arguments.of("foaf", IRI.create("http://xmlns.com/foaf/0.1/"))
+        );
+    }
+}

--- a/jopa-owl2java/src/test/java/cz/cvut/kbss/jopa/owl2java/TestUtils.java
+++ b/jopa-owl2java/src/test/java/cz/cvut/kbss/jopa/owl2java/TestUtils.java
@@ -48,8 +48,8 @@ public class TestUtils {
         throw new AssertionError();
     }
 
-    public static String resolveMappingFilePath() throws UnsupportedEncodingException {
-        final URL resource = TestUtils.class.getClassLoader().getResource(MAPPING_FILE_NAME);
+    public static String resolveTestResourcesFilePath(String fileName) throws UnsupportedEncodingException {
+        final URL resource = TestUtils.class.getClassLoader().getResource(fileName);
         final String decodedPath = URLDecoder.decode(resource.getFile(), StandardCharsets.UTF_8.toString());
         final File mf = new File(decodedPath);
         return mf.getAbsolutePath();

--- a/jopa-owl2java/src/test/java/cz/cvut/kbss/jopa/owl2java/environment/Generator.java
+++ b/jopa-owl2java/src/test/java/cz/cvut/kbss/jopa/owl2java/environment/Generator.java
@@ -1,0 +1,16 @@
+package cz.cvut.kbss.jopa.owl2java.environment;
+
+import java.net.URI;
+import java.util.Random;
+
+public class Generator {
+
+
+    private static final Random RANDOM = new Random();
+
+    public static final String IRI_BASE = "https://onto.fel.cvut.cz/ontologies/jopa/owl2java/";
+
+    public static URI generateUri() {
+        return URI.create(IRI_BASE + RANDOM.nextInt());
+    }
+}

--- a/jopa-owl2java/src/test/java/cz/cvut/kbss/jopa/owl2java/prefix/PrefixCcRemotePrefixResolverTest.java
+++ b/jopa-owl2java/src/test/java/cz/cvut/kbss/jopa/owl2java/prefix/PrefixCcRemotePrefixResolverTest.java
@@ -1,0 +1,28 @@
+package cz.cvut.kbss.jopa.owl2java.prefix;
+
+import cz.cvut.kbss.jopa.owl2java.environment.Generator;
+import org.junit.jupiter.api.Test;
+import org.semanticweb.owlapi.model.IRI;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PrefixCcRemotePrefixResolverTest {
+
+    private final PrefixCcRemotePrefixResolver sut = new PrefixCcRemotePrefixResolver();
+
+    @Test
+    void resolvePrefixReturnsPrefixReturnedByPrefixCcService() {
+        final Optional<String> result = sut.resolvePrefix(IRI.create("http://xmlns.com/foaf/0.1/"));
+        assertTrue(result.isPresent());
+        assertEquals("foaf", result.get());
+    }
+
+    @Test
+    void resolvePrefixReturnsEmptyOptionalWhenPrefixCcServiceReturnsNotFound() {
+        final Optional<String> result = sut.resolvePrefix(IRI.create(Generator.generateUri()));
+        assertTrue(result.isEmpty());
+    }
+}

--- a/jopa-owl2java/src/test/resources/prefixMappingFile
+++ b/jopa-owl2java/src/test/resources/prefixMappingFile
@@ -1,0 +1,2 @@
+http://rdfs.org/sioc/ns#=sioc
+http://onto.fel.cvut.cz/ontologies/dataset-descriptor/=ddo

--- a/jopa-owlapi-utils/src/main/java/cz/cvut/kbss/jopa/util/MappingFileParser.java
+++ b/jopa-owlapi-utils/src/main/java/cz/cvut/kbss/jopa/util/MappingFileParser.java
@@ -40,7 +40,7 @@ public final class MappingFileParser {
     /**
      * Default delimiter of mappings in the mapping file.
      * <p>
-     * That is, on the left hand side of the delimiter would the original IRI and on the right hand side is the mapped
+     * That is, on the left-hand side of the delimiter would the original IRI and on the right-hand side is the mapped
      * value.
      */
     public static final String DEFAULT_DELIMITER = ">";


### PR DESCRIPTION
Resolves #85.

The behavior is as follows:
- OWL2Java resolves prefixes (which can be either annotation or data property assertions) via a configurable property (defaults to `http://purl.org/vocab/vann/preferredNamespacePrefix`. If then a term from that ontology clashes with another term from a different ontology, the resolved ontology prefix is used to disambiguate them. If no prefix was found, OWL2Java will attempt to extract the disambiguation prefix from the ontology IRI itself by extracting the part after the `#` or last `/`.
- This could lead to situations when some terms from the ontology are prefixed (because there was a conflict) and some not. To allow preventing this inconsistency, it is possible to configure OWL2Java to always output the term with ontology prefix (if available0.
- Since all the OWL entities from all ontologies are ordered by IRI before processing, the output should be stable.
- It is also possible to provide a prefix mapping file so that one can configure prefixes for ontologies they have no control over (a good example could be the SIOC ontology(http://rdfs.org/sioc/ns#), whose prefix is not defined and can thus be resolved to `ns`.
- Core ontologies/vocabularies like RDF(S), OWL, SKOS or DC Terms have prefixes predefined.
- Also, I changed the generation of ontology IRI constants to the Vocabulary file to use all caps. So now the field name would be, e.g., `ONTOLOGY_IRI_VANN` instead of `ONTOLOGY_IRI_vann`.

This PR contains breaking changes, which is why it is slated for the 2.0.0 release.