### PR TITLE
Feature/277 soql projection

### DIFF
--- a/jopa-impl/src/test/java/cz/cvut/kbss/jopa/query/criteria/CriteriaQueryTranslateQueryTest.java
+++ b/jopa-impl/src/test/java/cz/cvut/kbss/jopa/query/criteria/CriteriaQueryTranslateQueryTest.java
@@ -145,6 +145,51 @@ public class CriteriaQueryTranslateQueryTest {
             assertEquals(expectedSoqlQuery, generatedSoqlQuery);
         }
 
+    @Test
+    void testTranslateQueryCountProperty() {
+        CriteriaQueryImpl<Integer> query = cb.createQuery(Integer.class);
+        Root<OWLClassD> root = query.from(OWLClassD.class);
+        query.select(cb.count(root.getAttr("owlClassA")));
+
+        final String generatedSoqlQuery = query.translateQuery(criteriaParameterFiller);
+        final String expectedSoqlQuery = "SELECT COUNT(owlclassd.owlClassA) FROM OWLClassD owlclassd";
+        assertEquals(expectedSoqlQuery, generatedSoqlQuery);
+    }
+
+        @Test
+        void testTranslateQueryDistinctCountProperty() {
+            CriteriaQueryImpl<Integer> query = cb.createQuery(Integer.class);
+            Root<OWLClassD> root = query.from(OWLClassD.class);
+            query.select(cb.count(root.getAttr("owlClassA"))).distinct();
+
+            final String generatedSoqlQuery = query.translateQuery(criteriaParameterFiller);
+            final String expectedSoqlQuery = "SELECT DISTINCT COUNT(owlclassd.owlClassA) FROM OWLClassD owlclassd";
+            assertEquals(expectedSoqlQuery, generatedSoqlQuery);
+        }
+
+        @Test
+        void parseQuerySupportsCountWithProjectedAttribute() {
+            CriteriaQueryImpl<Integer> query = cb.createQuery(Integer.class);
+            Root<OWLClassD> root = query.from(OWLClassD.class);
+            query.select(cb.count(root.getAttr("owlClassA"))).distinct();
+
+            final String generatedSoqlQuery = query.translateQuery(criteriaParameterFiller);
+            final String expectedSoqlQuery = "SELECT DISTINCT COUNT(owlclassd.owlClassA) FROM OWLClassD owlclassd";
+            assertEquals(expectedSoqlQuery, generatedSoqlQuery);
+        }
+
+        @Test
+        void parseQuerySupportsCountWithProjectedAttributeAndRelatedAttribute() {
+            CriteriaQueryImpl<Integer> query = cb.createQuery(Integer.class);
+            Root<OWLClassD> root = query.from(OWLClassD.class);
+            query.select(cb.count(root.getAttr("owlClassA"))).distinct()
+                    .where(cb.equal(root.getAttr("owlClassA").getAttr("stringAttribute"), ""));
+
+            final String generatedSoqlQuery = query.translateQuery(criteriaParameterFiller);
+            final String expectedSoqlQuery = "SELECT DISTINCT COUNT(owlclassd.owlClassA) FROM OWLClassD owlclassd WHERE owlclassd.owlClassA.stringAttribute = :generatedName0";
+            assertEquals(expectedSoqlQuery, generatedSoqlQuery);
+        }
+
         @Test
         public void testTranslateQuerySelectPropertyPath() {
             CriteriaQueryImpl<String> query = cb.createQuery(String.class);

--- a/jopa-impl/src/test/java/cz/cvut/kbss/jopa/query/soql/SoqlQueryParserTest.java
+++ b/jopa-impl/src/test/java/cz/cvut/kbss/jopa/query/soql/SoqlQueryParserTest.java
@@ -749,6 +749,50 @@ public class SoqlQueryParserTest {
         parseAndAssertEquality(soql, expectedSparql);
     }
 
+    @Test
+    void parseQuerySupportsCountWithProjectedAttribute() {
+        final String soqlIdFirst = "SELECT COUNT(d.owlClassA) FROM OWLClassD d WHERE d.uri = :uri";
+        final String expectedSparql = "SELECT (COUNT(?owlClassA) AS ?count) WHERE { ?uri a " + strUri(Vocabulary.c_OwlClassD) + " . " +
+                "?uri " + strUri(Vocabulary.p_h_hasA) + " ?owlClassA . }";
+        parseAndAssertEquality(soqlIdFirst, expectedSparql);
+    }
+
+    @Test
+    void parseQuerySupportsDistinctCountWithProjectedAttribute() {
+        final String soqlIdFirst = "SELECT DISTINCT COUNT(d.owlClassA) FROM OWLClassD d WHERE d.uri = :uri";
+        final String expectedSparql = "SELECT (COUNT(DISTINCT ?owlClassA) AS ?count) WHERE { ?uri a " + strUri(Vocabulary.c_OwlClassD) + " . " +
+                "?uri " + strUri(Vocabulary.p_h_hasA) + " ?owlClassA . }";
+        parseAndAssertEquality(soqlIdFirst, expectedSparql);
+    }
+
+    @Test
+    void parseQueryWithProjectedAttribute() {
+        final String soqlIdFirst = "SELECT d.owlClassA FROM OWLClassD d WHERE d.uri = :uri";
+        final String expectedSparql = "SELECT ?owlClassA WHERE { ?uri a " + strUri(Vocabulary.c_OwlClassD) + " . " +
+                "?uri " + strUri(Vocabulary.p_h_hasA) + " ?owlClassA . }";
+        parseAndAssertEquality(soqlIdFirst, expectedSparql);
+    }
+
+    @Test
+    void parseQueryWithProjectedAttributeAndRelatedAttribute() {
+        final String soqlIdFirst = "SELECT d.owlClassA FROM OWLClassD d WHERE d.uri = :uri AND d.owlClassA.stringAttribute = :stringAtt";
+        final String expectedSparql = "SELECT ?owlClassA WHERE { ?uri a " + strUri(Vocabulary.c_OwlClassD) + " . " +
+                "?uri " + strUri(Vocabulary.p_h_hasA) + " ?owlClassA . " + // FIXME: Duplicated SPARQL #281
+                "?uri " + strUri(Vocabulary.p_h_hasA) + " ?owlClassA . " +
+                "?owlClassA " + strUri(Vocabulary.p_a_stringAttribute) + " ?stringAtt . }";
+        parseAndAssertEquality(soqlIdFirst, expectedSparql);
+    }
+
+    @Test
+    void parseQueryWithDistinctProjectedAttributeAndRelatedAttribute() {
+        final String soqlIdFirst = "SELECT DISTINCT d.owlClassA FROM OWLClassD d WHERE d.uri = :uri AND d.owlClassA.stringAttribute = :stringAtt";
+        final String expectedSparql = "SELECT DISTINCT ?owlClassA WHERE { ?uri a " + strUri(Vocabulary.c_OwlClassD) + " . " +
+                "?uri " + strUri(Vocabulary.p_h_hasA) + " ?owlClassA . " + // FIXME: Duplicated SPARQL #281
+                "?uri " + strUri(Vocabulary.p_h_hasA) + " ?owlClassA . " +
+                "?owlClassA " + strUri(Vocabulary.p_a_stringAttribute) + " ?stringAtt . }";
+        parseAndAssertEquality(soqlIdFirst, expectedSparql);
+    }
+
     /**
      * Bug #178
      */


### PR DESCRIPTION
This fixes #277 by enabling attribute projection within SOQL. The CriteriaQuery already allowed for this behavior, so the tests where simply extended