### PR TITLE
Feature/276 sparql annotation as list

### DIFF
--- a/jopa-impl/src/main/java/cz/cvut/kbss/jopa/oom/query/PluralQueryAttributeStrategy.java
+++ b/jopa-impl/src/main/java/cz/cvut/kbss/jopa/oom/query/PluralQueryAttributeStrategy.java
@@ -30,7 +30,7 @@ public class PluralQueryAttributeStrategy<X> extends QueryFieldStrategy<PluralQu
 
     public PluralQueryAttributeStrategy(EntityType<X> et, PluralQueryAttributeImpl<? super X, ?, ?> attribute) {
         super(et, attribute);
-        this.values = CollectionFactory.createDefaultCollection(attribute.getCollectionType());
+        this.values = CollectionFactory.createDefaultQueryCollection(attribute.getCollectionType());
     }
 
     @Override

--- a/jopa-impl/src/main/java/cz/cvut/kbss/jopa/utils/CollectionFactory.java
+++ b/jopa-impl/src/main/java/cz/cvut/kbss/jopa/utils/CollectionFactory.java
@@ -61,6 +61,21 @@ public final class CollectionFactory {
     }
 
     /**
+     * Creates a default collection for the specified collection type in the context of Queries.
+     * This differs from {@link CollectionFactory#createDefaultCollection}, because SPARQL results are treated as lists,
+     * so Collections should be handled as Lists, not as Sets
+     *
+     * @param collectionType Type of the collection to create
+     * @return Collection implementation instance
+     */
+    public static <T> Collection<T> createDefaultQueryCollection(CollectionType collectionType) {
+        if(collectionType.equals(CollectionType.COLLECTION)) {
+            collectionType = CollectionType.LIST;
+        }
+        return createDefaultCollection(collectionType);
+    }
+
+    /**
      * Creates default instance of {@link Map}.
      *
      * @return Default Map implementation instance

--- a/jopa-impl/src/test/java/cz/cvut/kbss/jopa/utils/CollectionFactoryTest.java
+++ b/jopa-impl/src/test/java/cz/cvut/kbss/jopa/utils/CollectionFactoryTest.java
@@ -42,9 +42,23 @@ class CollectionFactoryTest {
 
     static Stream<Arguments> collectionTypeMapping() {
         return Stream.of(
+                Arguments.of(CollectionType.COLLECTION, Set.class),
                 Arguments.of(CollectionType.LIST, List.class),
-                Arguments.of(CollectionType.SET, Set.class),
-                Arguments.of(CollectionType.COLLECTION, Set.class)
+                Arguments.of(CollectionType.SET, Set.class)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("queryCollectionTypeMapping")
+    void createDefaultQueryCollectionReturnsCorrectTypeInstance(CollectionType collectionType, Class<?> expected) {
+        assertInstanceOf(expected, CollectionFactory.createDefaultQueryCollection(collectionType));
+    }
+
+    static Stream<Arguments> queryCollectionTypeMapping() {
+        return Stream.of(
+                Arguments.of(CollectionType.COLLECTION, List.class),
+                Arguments.of(CollectionType.LIST, List.class),
+                Arguments.of(CollectionType.SET, Set.class)
         );
     }
 

--- a/jopa-integration-tests-owlapi/src/test/java/cz/cvut/kbss/jopa/test/integration/owlapi/RetrieveOperationsTest.java
+++ b/jopa-integration-tests-owlapi/src/test/java/cz/cvut/kbss/jopa/test/integration/owlapi/RetrieveOperationsTest.java
@@ -20,6 +20,8 @@ package cz.cvut.kbss.jopa.test.integration.owlapi;
 import cz.cvut.kbss.jopa.test.environment.OwlapiDataAccessor;
 import cz.cvut.kbss.jopa.test.environment.OwlapiPersistenceFactory;
 import cz.cvut.kbss.jopa.test.runner.RetrieveOperationsRunner;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,5 +38,26 @@ public class RetrieveOperationsTest extends RetrieveOperationsRunner {
     @Override
     protected void addFileStorageProperties(Map<String, String> properties) {
         // Do nothing
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void testRetrieveWithCollectionQueryAttribute() {
+        // disabled because OWL2Query does not support SPARQL VALUES keyword
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void testRetrieveWithSetQueryAttribute() {
+        // disabled because OWL2Query does not support SPARQL VALUES keyword
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void testRetrieveWithListQueryAttribute() {
+        // disabled because OWL2Query does not support SPARQL VALUES keyword
     }
 }

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/OWLClassWithQueryAttr7.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/OWLClassWithQueryAttr7.java
@@ -1,0 +1,99 @@
+/*
+ * JOPA
+ * Copyright (C) 2024 Czech Technical University in Prague
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package cz.cvut.kbss.jopa.test;
+
+import cz.cvut.kbss.jopa.model.annotations.Id;
+import cz.cvut.kbss.jopa.model.annotations.OWLClass;
+import cz.cvut.kbss.jopa.model.annotations.Sparql;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+@OWLClass(iri = Vocabulary.C_OwlClassWithQueryAttr6)
+public class OWLClassWithQueryAttr7 implements HasUri {
+
+    private static final String QUERY = "SELECT ?x WHERE { VALUES (?x) {(99)(2)(99)}}";
+
+    @Id
+    private URI uri;
+
+    @Sparql(query=QUERY)
+    private Collection<Integer> collectionQueryAttribute;
+
+    @Sparql(query=QUERY)
+    private Set<Integer> setQueryAttribute;
+
+    @Sparql(query=QUERY)
+    private List<Integer> listQueryAttribute;
+
+    public OWLClassWithQueryAttr7() {
+    }
+
+    public OWLClassWithQueryAttr7(URI uri) {
+        this.uri = uri;
+    }
+
+    public void setUri(URI uri) {
+        this.uri = uri;
+    }
+
+    @Override
+    public URI getUri() {
+        return uri;
+    }
+
+    public Collection<Integer> getCollectionQueryAttribute() {
+        return collectionQueryAttribute;
+    }
+
+    public void setCollectionQueryAttribute(Collection<Integer> collectionQueryAttribute) {
+        this.collectionQueryAttribute = collectionQueryAttribute;
+    }
+
+    public Set<Integer> getSetQueryAttribute() {
+        return setQueryAttribute;
+    }
+
+    public void setSetQueryAttribute(Set<Integer> setQueryAttribute) {
+        this.setQueryAttribute = setQueryAttribute;
+    }
+
+    public List<Integer> getListQueryAttribute() {
+        return listQueryAttribute;
+    }
+
+    public void setListQueryAttribute(List<Integer> listQueryAttribute) {
+        this.listQueryAttribute = listQueryAttribute;
+    }
+
+    public static String getSparqlQuery() {
+        return QUERY;
+    }
+
+    @Override
+    public String toString() {
+        return "OWLClassWithQueryAttr7{" +
+                "uri=" + uri +
+                ", collectionQueryAttribute=" + collectionQueryAttribute +
+                ", setQueryAttribute=" + setQueryAttribute +
+                ", listQueryAttribute=" + listQueryAttribute +
+                '}';
+    }
+}

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/BaseRunner.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/BaseRunner.java
@@ -39,6 +39,7 @@ import cz.cvut.kbss.jopa.test.OWLClassWithQueryAttr3;
 import cz.cvut.kbss.jopa.test.OWLClassWithQueryAttr4;
 import cz.cvut.kbss.jopa.test.OWLClassWithQueryAttr5;
 import cz.cvut.kbss.jopa.test.OWLClassWithQueryAttr6;
+import cz.cvut.kbss.jopa.test.OWLClassWithQueryAttr7;
 import cz.cvut.kbss.jopa.test.environment.DataAccessor;
 import cz.cvut.kbss.jopa.test.environment.PersistenceFactory;
 import cz.cvut.kbss.jopa.test.environment.Quad;
@@ -91,6 +92,7 @@ public abstract class BaseRunner {
     protected OWLClassWithQueryAttr4 entityWithQueryAttr4;
     protected OWLClassWithQueryAttr5 entityWithQueryAttr5;
     protected OWLClassWithQueryAttr6 entityWithQueryAttr6;
+    protected OWLClassWithQueryAttr7 entityWithQueryAttr7;
     // Dynamic attributes
     protected OWLClassAA entityAA;
 
@@ -173,6 +175,8 @@ public abstract class BaseRunner {
         entityWithQueryAttr5.setUri(URI.create("http://krizik.felk.cvut.cz/ontologies/jopa/tests/entityWithQueryAttr5"));
         this.entityWithQueryAttr6 = new OWLClassWithQueryAttr6();
         entityWithQueryAttr6.setUri(URI.create("http://krizik.felk.cvut.cz/ontologies/jopa/tests/entityWithQueryAttr6"));
+        this.entityWithQueryAttr7 = new OWLClassWithQueryAttr7();
+        entityWithQueryAttr7.setUri(URI.create("http://krizik.felk.cvut.cz/ontologies/jopa/tests/entityWithQueryAttr7"));
         this.entityAA = new OWLClassAA();
         this.entityAA.setUri(URI.create("http://krizik.felk.cvut.cz/ontologies/jopa/tests/entityAA"));
     }

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/RetrieveOperationsRunner.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/RetrieveOperationsRunner.java
@@ -37,6 +37,7 @@ import cz.cvut.kbss.jopa.test.OWLClassV;
 import cz.cvut.kbss.jopa.test.OWLClassWithQueryAttr;
 import cz.cvut.kbss.jopa.test.OWLClassWithQueryAttr2;
 import cz.cvut.kbss.jopa.test.OWLClassWithQueryAttr6;
+import cz.cvut.kbss.jopa.test.OWLClassWithQueryAttr7;
 import cz.cvut.kbss.jopa.test.OWLClassWithUrn;
 import cz.cvut.kbss.jopa.test.Thing;
 import cz.cvut.kbss.jopa.test.Vocabulary;
@@ -62,6 +63,7 @@ import java.nio.file.StandardCopyOption;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -542,6 +544,45 @@ public abstract class RetrieveOperationsRunner extends BaseRunner {
         assertNotNull(value);
         assertEquals(entityD.getUri(), res.getLazyQueryAttribute().getUri());
     }
+
+
+    @Test
+    public void testRetrieveWithCollectionQueryAttribute() {
+        this.em = getEntityManager("RetrieveWithPluralQueryAttribute", false);
+
+        persist(entityWithQueryAttr7);
+        final OWLClassWithQueryAttr7 res = findRequired(OWLClassWithQueryAttr7.class, entityWithQueryAttr7.getUri());
+        Collection<Integer> result = res.getCollectionQueryAttribute();
+        assertInstanceOf(List.class, result);
+        assertEquals(3, result.size());
+        assertEquals(2, result.stream().filter(i -> i.equals(99)).count());
+    }
+
+    @Test
+    public void testRetrieveWithSetQueryAttribute() {
+        this.em = getEntityManager("RetrieveWithPluralQueryAttribute", false);
+
+        persist(entityWithQueryAttr7);
+        final OWLClassWithQueryAttr7 res = findRequired(OWLClassWithQueryAttr7.class, entityWithQueryAttr7.getUri());
+        Set<Integer> result = res.getSetQueryAttribute();
+        assertInstanceOf(Set.class, result);
+        assertEquals(2, result.size());
+        assertTrue(result.containsAll(List.of(99, 2)));
+    }
+
+    @Test
+    public void testRetrieveWithListQueryAttribute() {
+        this.em = getEntityManager("RetrieveWithPluralQueryAttribute", false);
+
+        persist(entityWithQueryAttr7);
+        final OWLClassWithQueryAttr7 res = findRequired(OWLClassWithQueryAttr7.class, entityWithQueryAttr7.getUri());
+        Collection<Integer> result = res.getCollectionQueryAttribute();
+        assertInstanceOf(List.class, result);
+        assertEquals(3, result.size());
+        assertEquals(2, result.stream().filter(i -> i.equals(99)).count());
+    }
+
+
 
     @Test
     void testSupportForUrnIrisInClassAndProperty() {


### PR DESCRIPTION
Fixes #276 by treating `Collection`s as `List`s instead of `Set`s by default