### PR TITLE
Support primitive java types

### DIFF
--- a/datatype/src/main/java/cz/cvut/kbss/jopa/datatype/DatatypeTransformer.java
+++ b/datatype/src/main/java/cz/cvut/kbss/jopa/datatype/DatatypeTransformer.java
@@ -41,8 +41,22 @@ public class DatatypeTransformer {
 
     private static final Map<Pair, Function<Object, ?>> TRANSFORMERS = initTransformers();
 
+    private static final Map<Class<?>, Class<?>> WRAPPER_TO_PRIMITIVES = initWrapperToPrimitives();
+
     private DatatypeTransformer() {
         throw new AssertionError();
+    }
+
+    private static Map<Class<?>, Class<?>> initWrapperToPrimitives() {
+        final Map<Class<?>, Class<?>> map = new HashMap<>();
+        map.put(Integer.class, int.class);
+        map.put(Boolean.class, boolean.class);
+        map.put(Byte.class, byte.class);
+        map.put(Short.class, short.class);
+        map.put(Long.class, long.class);
+        map.put(Float.class, float.class);
+        map.put(Double.class, double.class);
+        return map;
     }
 
     private static Map<Pair, Function<Object, ?>> initTransformers() {
@@ -77,6 +91,19 @@ public class DatatypeTransformer {
         map.put(new Pair(BigInteger.class, Integer.class), value -> ((BigInteger) value).intValueExact());
         map.put(new Pair(BigInteger.class, Long.class), value -> ((BigInteger) value).longValueExact());
         return map;
+    }
+
+    /**
+     * Converts the specified wrapper class to its corresponding primitive class.
+     *
+     * If the class parameter is a wrapper type, the equivalent primitive type will be returned (e.g. int.class for Integer.class)
+     * In all other cases, the return value is null.
+     *
+     * @param cls - the class to convert
+     * @return
+     */
+    public static Class<?> wrapperToPrimitive( Class<?> cls ) {
+        return WRAPPER_TO_PRIMITIVES.get(cls);
     }
 
     /**

--- a/datatype/src/main/java/cz/cvut/kbss/jopa/datatype/DatatypeTransformer.java
+++ b/datatype/src/main/java/cz/cvut/kbss/jopa/datatype/DatatypeTransformer.java
@@ -41,22 +41,18 @@ public class DatatypeTransformer {
 
     private static final Map<Pair, Function<Object, ?>> TRANSFORMERS = initTransformers();
 
-    private static final Map<Class<?>, Class<?>> WRAPPER_TO_PRIMITIVES = initWrapperToPrimitives();
+    private static final Map<Class<?>, Class<?>> WRAPPER_TO_PRIMITIVES = Map.of(
+            Integer.class, int.class,
+            Boolean.class, boolean.class,
+            Byte.class, byte.class,
+            Short.class, short.class,
+            Long.class, long.class,
+            Float.class, float.class,
+            Double.class, double.class
+    );
 
     private DatatypeTransformer() {
         throw new AssertionError();
-    }
-
-    private static Map<Class<?>, Class<?>> initWrapperToPrimitives() {
-        final Map<Class<?>, Class<?>> map = new HashMap<>();
-        map.put(Integer.class, int.class);
-        map.put(Boolean.class, boolean.class);
-        map.put(Byte.class, byte.class);
-        map.put(Short.class, short.class);
-        map.put(Long.class, long.class);
-        map.put(Float.class, float.class);
-        map.put(Double.class, double.class);
-        return map;
     }
 
     private static Map<Pair, Function<Object, ?>> initTransformers() {
@@ -102,8 +98,11 @@ public class DatatypeTransformer {
      * @param cls - the class to convert
      * @return
      */
-    public static Class<?> wrapperToPrimitive( Class<?> cls ) {
-        return WRAPPER_TO_PRIMITIVES.get(cls);
+    public static Optional<Class<?>> wrapperTypeToPrimitiveType(Class<?> cls) {
+        if(cls != null && WRAPPER_TO_PRIMITIVES.containsKey(cls)) {
+            return Optional.of(WRAPPER_TO_PRIMITIVES.get(cls));
+        }
+        return Optional.empty();
     }
 
     /**

--- a/datatype/src/test/java/cz/cvut/kbss/jopa/datatype/DatatypeTransformerTest.java
+++ b/datatype/src/test/java/cz/cvut/kbss/jopa/datatype/DatatypeTransformerTest.java
@@ -33,6 +33,29 @@ import static org.junit.jupiter.api.Assertions.*;
 class DatatypeTransformerTest {
 
     @Test
+    void wrapperToPrimitiveReturnsNullForNullInput() {
+        assertNull(DatatypeTransformer.wrapperToPrimitive(null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("wrapperToPrimitiveTestValues")
+    void wrapperToPrimitive(Class<?> wrapper, Class<?> primitive) {
+        assertEquals(primitive, DatatypeTransformer.wrapperToPrimitive(wrapper));
+    }
+
+    private static Stream<Arguments> wrapperToPrimitiveTestValues() {
+        return Stream.of(
+                Arguments.arguments(Integer.class, int.class),
+                Arguments.arguments(Boolean.class, boolean.class),
+                Arguments.arguments(Byte.class, byte.class),
+                Arguments.arguments(Short.class, short.class),
+                Arguments.arguments(Long.class, long.class),
+                Arguments.arguments(Float.class, float.class),
+                Arguments.arguments(Double.class, double.class)
+        );
+    }
+
+    @Test
     void transformReturnsNullForNullInput() {
         assertNull(DatatypeTransformer.transform(null, String.class));
     }

--- a/datatype/src/test/java/cz/cvut/kbss/jopa/datatype/DatatypeTransformerTest.java
+++ b/datatype/src/test/java/cz/cvut/kbss/jopa/datatype/DatatypeTransformerTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.net.InetAddress;
 import java.net.URL;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -33,17 +34,17 @@ import static org.junit.jupiter.api.Assertions.*;
 class DatatypeTransformerTest {
 
     @Test
-    void wrapperToPrimitiveReturnsNullForNullInput() {
-        assertNull(DatatypeTransformer.wrapperToPrimitive(null));
+    void wrapperTypeToPrimitiveTypeReturnsNullForNullInput() {
+        assertEquals(Optional.empty(), DatatypeTransformer.wrapperTypeToPrimitiveType(null));
     }
 
     @ParameterizedTest
-    @MethodSource("wrapperToPrimitiveTestValues")
-    void wrapperToPrimitive(Class<?> wrapper, Class<?> primitive) {
-        assertEquals(primitive, DatatypeTransformer.wrapperToPrimitive(wrapper));
+    @MethodSource("wrapperTypeToPrimitiveTypeTestValues")
+    void wrapperTypeToPrimitiveType(Class<?> wrapper, Class<?> primitive) {
+        assertEquals(Optional.of(primitive), DatatypeTransformer.wrapperTypeToPrimitiveType(wrapper));
     }
 
-    private static Stream<Arguments> wrapperToPrimitiveTestValues() {
+    private static Stream<Arguments> wrapperTypeToPrimitiveTypeTestValues() {
         return Stream.of(
                 Arguments.arguments(Integer.class, int.class),
                 Arguments.arguments(Boolean.class, boolean.class),

--- a/jopa-impl/src/main/java/cz/cvut/kbss/jopa/model/metamodel/ClassFieldMetamodelProcessor.java
+++ b/jopa-impl/src/main/java/cz/cvut/kbss/jopa/model/metamodel/ClassFieldMetamodelProcessor.java
@@ -82,9 +82,6 @@ class ClassFieldMetamodelProcessor<X> {
             }
             return;
         }
-        if (field.getType().isPrimitive()) {
-            throw new MetamodelInitializationException("Primitive types cannot be used for entity fields. Field " + field + " in class " + cls);
-        }
 
         final Class<?> fieldValueCls = getFieldValueType(field);
         field.setAccessible(true);

--- a/jopa-impl/src/main/java/cz/cvut/kbss/jopa/model/metamodel/Converters.java
+++ b/jopa-impl/src/main/java/cz/cvut/kbss/jopa/model/metamodel/Converters.java
@@ -29,6 +29,7 @@ import cz.cvut.kbss.jopa.oom.converter.ToShortConverter;
 import cz.cvut.kbss.jopa.oom.converter.ToStringConverter;
 import cz.cvut.kbss.jopa.oom.converter.ToURIConverter;
 import cz.cvut.kbss.jopa.oom.converter.ToURLConverter;
+import cz.cvut.kbss.jopa.oom.converter.CharacterConverter;
 import cz.cvut.kbss.jopa.oom.converter.datetime.DateConverter;
 import cz.cvut.kbss.jopa.oom.converter.datetime.InstantConverter;
 import cz.cvut.kbss.jopa.oom.converter.datetime.LocalDateTimeConverter;
@@ -91,7 +92,8 @@ public class Converters {
                 Map.entry(String.class, new ToStringConverter()),
                 Map.entry(LangString.class, new ToLangStringConverter()),
                 Map.entry(URI.class, new ToURIConverter()),
-                Map.entry(URL.class, new ToURLConverter()));
+                Map.entry(URL.class, new ToURLConverter()),
+                Map.entry(Character.class, new CharacterConverter()));
     }
 
     /**

--- a/jopa-impl/src/main/java/cz/cvut/kbss/jopa/model/metamodel/Converters.java
+++ b/jopa-impl/src/main/java/cz/cvut/kbss/jopa/model/metamodel/Converters.java
@@ -93,7 +93,8 @@ public class Converters {
                 Map.entry(LangString.class, new ToLangStringConverter()),
                 Map.entry(URI.class, new ToURIConverter()),
                 Map.entry(URL.class, new ToURLConverter()),
-                Map.entry(Character.class, new CharacterConverter()));
+                Map.entry(Character.class, new CharacterConverter()),
+                Map.entry(char.class, new CharacterConverter()));
     }
 
     /**

--- a/jopa-impl/src/main/java/cz/cvut/kbss/jopa/model/metamodel/PropertyAttributes.java
+++ b/jopa-impl/src/main/java/cz/cvut/kbss/jopa/model/metamodel/PropertyAttributes.java
@@ -17,6 +17,7 @@
  */
 package cz.cvut.kbss.jopa.model.metamodel;
 
+import cz.cvut.kbss.jopa.datatype.DatatypeTransformer;
 import cz.cvut.kbss.jopa.model.IRI;
 import cz.cvut.kbss.jopa.model.MultilingualString;
 import cz.cvut.kbss.jopa.model.annotations.CascadeType;
@@ -133,7 +134,9 @@ abstract class PropertyAttributes {
     }
 
     String resolveLanguage(Class<?> fieldValueCls) {
-        return MultilingualString.class.equals(fieldValueCls) || Character.class.equals(fieldValueCls) ? null : typeBuilderContext.getPuLanguage();
+        return MultilingualString.class.equals(fieldValueCls) || Character.class.equals(fieldValueCls) || char.class.equals(fieldValueCls)
+                ? null
+                : typeBuilderContext.getPuLanguage();
     }
 
     static PropertyAttributes create(PropertyInfo field, FieldMappingValidator validator, TypeBuilderContext<?> context) {

--- a/jopa-impl/src/main/java/cz/cvut/kbss/jopa/model/metamodel/PropertyAttributes.java
+++ b/jopa-impl/src/main/java/cz/cvut/kbss/jopa/model/metamodel/PropertyAttributes.java
@@ -133,7 +133,7 @@ abstract class PropertyAttributes {
     }
 
     String resolveLanguage(Class<?> fieldValueCls) {
-        return MultilingualString.class.equals(fieldValueCls) ? null : typeBuilderContext.getPuLanguage();
+        return MultilingualString.class.equals(fieldValueCls) || Character.class.equals(fieldValueCls) ? null : typeBuilderContext.getPuLanguage();
     }
 
     static PropertyAttributes create(PropertyInfo field, FieldMappingValidator validator, TypeBuilderContext<?> context) {

--- a/jopa-impl/src/main/java/cz/cvut/kbss/jopa/oom/DataPropertyFieldStrategy.java
+++ b/jopa-impl/src/main/java/cz/cvut/kbss/jopa/oom/DataPropertyFieldStrategy.java
@@ -28,6 +28,7 @@ import cz.cvut.kbss.ontodriver.model.Value;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
 
 abstract class DataPropertyFieldStrategy<A extends AbstractAttribute<? super X, ?>, X> extends FieldStrategy<A, X> {
 
@@ -44,10 +45,10 @@ abstract class DataPropertyFieldStrategy<A extends AbstractAttribute<? super X, 
     }
 
     boolean canBeConverted(Object value) {
-        if(attribute.getJavaType() != null && attribute.getJavaType().isPrimitive()) {
+        if(attribute.getJavaType().isPrimitive()) {
             // if the value is a wrapper for the primitive attribute type, it can be converted automatically
-            Class<?> primitiveClass = DatatypeTransformer.wrapperToPrimitive(value.getClass());
-            if (primitiveClass != null && primitiveClass.equals(attribute.getJavaType())) {
+            Optional<Class<?>> primitiveClass = DatatypeTransformer.wrapperTypeToPrimitiveType(value.getClass());
+            if (primitiveClass.isPresent() && primitiveClass.get().equals(attribute.getJavaType())) {
                 return true;
             }
         }

--- a/jopa-impl/src/main/java/cz/cvut/kbss/jopa/oom/DataPropertyFieldStrategy.java
+++ b/jopa-impl/src/main/java/cz/cvut/kbss/jopa/oom/DataPropertyFieldStrategy.java
@@ -17,6 +17,7 @@
  */
 package cz.cvut.kbss.jopa.oom;
 
+import cz.cvut.kbss.jopa.datatype.DatatypeTransformer;
 import cz.cvut.kbss.jopa.model.descriptors.Descriptor;
 import cz.cvut.kbss.jopa.model.metamodel.AbstractAttribute;
 import cz.cvut.kbss.jopa.model.metamodel.EntityType;
@@ -43,6 +44,14 @@ abstract class DataPropertyFieldStrategy<A extends AbstractAttribute<? super X, 
     }
 
     boolean canBeConverted(Object value) {
+        if(attribute.getJavaType() != null && attribute.getJavaType().isPrimitive()) {
+            // if the value is a wrapper for the primitive attribute type, it can be converted automatically
+            Class<?> primitiveClass = DatatypeTransformer.wrapperToPrimitive(value.getClass());
+            if (primitiveClass != null && primitiveClass.equals(attribute.getJavaType())) {
+                return true;
+            }
+        }
+
         return converter.supportsAxiomValueType(value.getClass());
     }
 

--- a/jopa-impl/src/main/java/cz/cvut/kbss/jopa/oom/converter/CharacterConverter.java
+++ b/jopa-impl/src/main/java/cz/cvut/kbss/jopa/oom/converter/CharacterConverter.java
@@ -17,6 +17,7 @@
  */
 package cz.cvut.kbss.jopa.oom.converter;
 
+import cz.cvut.kbss.jopa.datatype.exception.DatatypeMappingException;
 import cz.cvut.kbss.ontodriver.model.LangString;
 
 /**
@@ -34,12 +35,12 @@ public class CharacterConverter implements ConverterWrapper<Character, Object> {
 
     @Override
     public Character convertToAttribute(Object value) {
-        assert value != null;
-        if (value instanceof LangString ls) {
-            value = ls.getValue();
+        assert value != null && value instanceof String;
+
+        if(((String) value).length() > 1) {
+            throw new DatatypeMappingException("Unable to map literal " + value + " to " + Character.class.getCanonicalName() + ", because its length is greater than 1");
         }
 
-        assert value instanceof String && ((String) value).length() == 1;
         return ((String) value).charAt(0);
     }
 

--- a/jopa-impl/src/main/java/cz/cvut/kbss/jopa/oom/converter/CharacterConverter.java
+++ b/jopa-impl/src/main/java/cz/cvut/kbss/jopa/oom/converter/CharacterConverter.java
@@ -1,0 +1,50 @@
+/*
+ * JOPA
+ * Copyright (C) 2024 Czech Technical University in Prague
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package cz.cvut.kbss.jopa.oom.converter;
+
+import cz.cvut.kbss.ontodriver.model.LangString;
+
+/**
+ * Converts between {@link Character} and a xsd:string representation.
+ * <p>
+ * This converter supports {@link String} and {@link LangString} as character representations.
+ */
+public class CharacterConverter implements ConverterWrapper<Character, Object> {
+
+    @Override
+    public Object convertToAxiomValue(Character value) {
+        assert value != null;
+        return value.toString();
+    }
+
+    @Override
+    public Character convertToAttribute(Object value) {
+        assert value != null;
+        if (value instanceof LangString ls) {
+            value = ls.getValue();
+        }
+
+        assert value instanceof String && ((String) value).length() == 1;
+        return ((String) value).charAt(0);
+    }
+
+    @Override
+    public boolean supportsAxiomValueType(Class<?> type) {
+        return String.class.isAssignableFrom(type);
+    }
+}

--- a/jopa-impl/src/test/java/cz/cvut/kbss/jopa/environment/OWLClassM.java
+++ b/jopa-impl/src/test/java/cz/cvut/kbss/jopa/environment/OWLClassM.java
@@ -54,6 +54,9 @@ public class OWLClassM {
     @OWLDataProperty(iri = Vocabulary.p_m_dateAttribute)
     private Date dateAttribute;
 
+    @OWLDataProperty(iri = Vocabulary.p_m_characterAttribute)
+    private Character characterAttribute;
+
     @OWLDataProperty(iri = Vocabulary.p_m_enumAttribute)
     private Severity enumAttribute;
 
@@ -133,6 +136,14 @@ public class OWLClassM {
         this.dateAttribute = dateAttribute;
     }
 
+    public Character getCharacterAttribute() {
+        return characterAttribute;
+    }
+
+    public void setCharacterAttribute(Character characterAttribute) {
+        this.characterAttribute = characterAttribute;
+    }
+
     public Severity getEnumAttribute() {
         return enumAttribute;
     }
@@ -191,12 +202,14 @@ public class OWLClassM {
 
     @Override
     public String toString() {
-        return "OWLCLassM{" +
+        return "OWLClassM{" +
                 "key='" + key + '\'' +
                 ", booleanAttribute=" + booleanAttribute +
                 ", intAttribute=" + intAttribute +
                 ", longAttribute=" + longAttribute +
                 ", doubleAttribute=" + doubleAttribute +
+                ", dateAttribute=" + dateAttribute +
+                ", characterAttribute=" + characterAttribute +
                 ", enumAttribute=" + enumAttribute +
                 ", ordinalEnumAttribute=" + ordinalEnumAttribute +
                 ", integerSet=" + integerSet +
@@ -217,6 +230,7 @@ public class OWLClassM {
         this.longAttribute = 365L;
         this.doubleAttribute = 3.14D;
         this.dateAttribute = new Date();
+        this.characterAttribute = 'j';
         this.enumAttribute = Severity.MEDIUM;
         this.ordinalEnumAttribute = enumAttribute;
         this.integerSet = IntStream.generate(Generators::randomInt).limit(10).boxed().collect(Collectors.toSet());
@@ -261,6 +275,14 @@ public class OWLClassM {
 
     public static PropertyInfo getDateAttributeFieldPropertyInfo() throws Exception {
         return PropertyInfo.from(OWLClassM.getDateAttributeField());
+    }
+
+    public static Field getCharacterAttributeField() throws Exception {
+        return OWLClassM.class.getDeclaredField("characterAttribute");
+    }
+
+    public static PropertyInfo getCharacterAttributeFieldPropertyInfo() throws Exception {
+        return PropertyInfo.from(OWLClassM.getCharacterAttributeField());
     }
 
     public static Field getEnumAttributeField() throws Exception {

--- a/jopa-impl/src/test/java/cz/cvut/kbss/jopa/environment/Vocabulary.java
+++ b/jopa-impl/src/test/java/cz/cvut/kbss/jopa/environment/Vocabulary.java
@@ -61,6 +61,7 @@ public class Vocabulary {
     public static final String p_m_longAttribute = ATTRIBUTE_BASE + "m-longAttribute";
     public static final String p_m_doubleAttribute = ATTRIBUTE_BASE + "m-doubleAttribute";
     public static final String p_m_dateAttribute = ATTRIBUTE_BASE + "m-dateAttribute";
+    public static final String p_m_characterAttribute = ATTRIBUTE_BASE + "m-characterAttribute";
     public static final String p_m_enumAttribute = ATTRIBUTE_BASE + "m-enumAttribute";
     public static final String p_m_ordinalEnumAttribute = ATTRIBUTE_BASE + "m-ordinalEnumAttribute";
     public static final String p_m_IntegerSet = ATTRIBUTE_BASE + "m-pluralIntAttribute";

--- a/jopa-impl/src/test/java/cz/cvut/kbss/jopa/environment/utils/MetamodelFactory.java
+++ b/jopa-impl/src/test/java/cz/cvut/kbss/jopa/environment/utils/MetamodelFactory.java
@@ -95,6 +95,7 @@ import cz.cvut.kbss.jopa.oom.converter.ToDoubleConverter;
 import cz.cvut.kbss.jopa.oom.converter.ToIntegerConverter;
 import cz.cvut.kbss.jopa.oom.converter.ToLexicalFormConverter;
 import cz.cvut.kbss.jopa.oom.converter.ToLongConverter;
+import cz.cvut.kbss.jopa.oom.converter.CharacterConverter;
 import cz.cvut.kbss.jopa.oom.converter.datetime.LocalDateTimeConverter;
 import cz.cvut.kbss.jopa.utils.Configuration;
 import cz.cvut.kbss.jopa.vocabulary.DC;
@@ -735,7 +736,7 @@ public class MetamodelFactory {
 
     public static void initOWLClassMMock(IdentifiableEntityType<OWLClassM> etMock, AbstractAttribute booleanAtt,
                                          AbstractAttribute intAtt, SingularAttributeImpl longAtt,
-                                         AbstractAttribute doubleAtt, AbstractAttribute dateAtt,
+                                         AbstractAttribute doubleAtt, AbstractAttribute dateAtt, AbstractAttribute characterAtt,
                                          AbstractAttribute enumAtt, AbstractAttribute ordinalEnumAtt,
                                          AbstractPluralAttribute intSetAtt, SingularAttributeImpl lexicalFormAtt,
                                          SingularAttributeImpl simpleLiteralAtt,
@@ -755,13 +756,13 @@ public class MetamodelFactory {
         when(etMock.getFieldSpecification(idMock.getName())).thenReturn(idMock);
         when(etMock.getAttributes()).thenReturn(
                 new HashSet<>(Arrays.<Attribute<? super OWLClassM, ?>>asList(booleanAtt, intAtt, longAtt, doubleAtt,
-                        dateAtt, enumAtt, ordinalEnumAtt,
+                        dateAtt, characterAtt, enumAtt, ordinalEnumAtt,
                         intSetAtt, lexicalFormAtt,
                         simpleLiteralAtt, explicitDatatypeAtt,
                         mObjectOneOfEnumAttribute)));
         when(etMock.getFieldSpecifications()).thenReturn(new HashSet<>(
                 Arrays.<FieldSpecification<? super OWLClassM, ?>>asList(booleanAtt, intAtt, longAtt, doubleAtt, dateAtt,
-                        enumAtt, ordinalEnumAtt, intSetAtt,
+                        characterAtt, enumAtt, ordinalEnumAtt, intSetAtt,
                         lexicalFormAtt, simpleLiteralAtt,
                         explicitDatatypeAtt, mObjectOneOfEnumAttribute,
                         idMock)));
@@ -835,6 +836,20 @@ public class MetamodelFactory {
         when(dateAtt.getLanguage()).thenReturn(Generators.LANG);
         when(etMock.getFieldSpecification(OWLClassM.getDateAttributeField().getName())).thenReturn(dateAtt);
         when(etMock.getAttribute(OWLClassM.getDateAttributeField().getName())).thenReturn(dateAtt);
+
+        when(characterAtt.getJavaField()).thenReturn(OWLClassM.getCharacterAttributeField());
+        when(characterAtt.getName()).thenReturn(OWLClassM.getCharacterAttributeField().getName());
+        when(characterAtt.getJavaType()).thenReturn(OWLClassM.getCharacterAttributeField().getType());
+        when(characterAtt.getIRI()).thenReturn(IRI.create(Vocabulary.p_m_characterAttribute));
+        when(characterAtt.getPersistentAttributeType()).thenReturn(Attribute.PersistentAttributeType.DATA);
+        when(characterAtt.isCollection()).thenReturn(false);
+        when(characterAtt.getDeclaringType()).thenReturn(etMock);
+        when(characterAtt.getConstraints()).thenReturn(new ParticipationConstraint[0]);
+        when(characterAtt.getConverter()).thenReturn(new CharacterConverter());
+        when(characterAtt.hasLanguage()).thenReturn(true);
+        when(characterAtt.getLanguage()).thenReturn(Generators.LANG);
+        when(etMock.getFieldSpecification(OWLClassM.getCharacterAttributeField().getName())).thenReturn(characterAtt);
+        when(etMock.getAttribute(OWLClassM.getCharacterAttributeField().getName())).thenReturn(characterAtt);
 
         when(enumAtt.getJavaField()).thenReturn(OWLClassM.getEnumAttributeField());
         when(enumAtt.getName()).thenReturn(OWLClassM.getEnumAttributeField().getName());

--- a/jopa-impl/src/test/java/cz/cvut/kbss/jopa/environment/utils/MetamodelMocks.java
+++ b/jopa-impl/src/test/java/cz/cvut/kbss/jopa/environment/utils/MetamodelMocks.java
@@ -206,6 +206,8 @@ public class MetamodelMocks {
     @Mock
     private SingularAttributeImpl<OWLClassM, Date> mDateAtt;
     @Mock
+    private SingularAttributeImpl<OWLClassM, Character> mCharacterAtt;
+    @Mock
     private SingularAttributeImpl<OWLClassM, OWLClassM.Severity> mEnumAtt;
     @Mock
     private SingularAttributeImpl<OWLClassM, OWLClassM.Severity> mOrdinalEnumAtt;
@@ -388,7 +390,7 @@ public class MetamodelMocks {
         MetamodelFactory.initOWLClassJMocks(etJ, jSetAtt, idJ);
         MetamodelFactory.initOWLClassKMocks(etK, kOwlClassEAtt, idK);
         MetamodelFactory.initOWLClassLMocks(etL, lReferencedList, lSimpleList, lSetAtt, lOwlClassAAtt, idL);
-        MetamodelFactory.initOWLClassMMock(etM, mBooleanAtt, mIntegerAtt, mLongAtt, mDoubleAtt, mDateAtt, mEnumAtt,
+        MetamodelFactory.initOWLClassMMock(etM, mBooleanAtt, mIntegerAtt, mLongAtt, mDoubleAtt, mDateAtt, mCharacterAtt, mEnumAtt,
                                            mOrdinalEnumAtt, mIntegerSetAtt, mLexicalFormAtt, mSimpleLiteralAtt,
                                            mExplicitDatatypeAtt, mWithConverterAtt, mObjectOneOfEnumAttribute, idM);
         MetamodelFactory.initOWLClassNMock(etN, nAnnotationAtt, nAnnotationUriAtt, nStringAtt, nPluralAnnotationAtt,
@@ -784,6 +786,10 @@ public class MetamodelMocks {
 
         public AbstractAttribute<OWLClassM, Date> dateAttribute() {
             return MetamodelMocks.this.mDateAtt;
+        }
+
+        public AbstractAttribute<OWLClassM, Character> characterAttribute() {
+            return MetamodelMocks.this.mCharacterAtt;
         }
 
         public AbstractAttribute<OWLClassM, OWLClassM.Severity> enumAttribute() {

--- a/jopa-impl/src/test/java/cz/cvut/kbss/jopa/model/MetamodelImplTest.java
+++ b/jopa-impl/src/test/java/cz/cvut/kbss/jopa/model/MetamodelImplTest.java
@@ -181,6 +181,12 @@ class MetamodelImplTest {
                                FetchType.EAGER, false, dateField.getAnnotation(OWLDataProperty.class).iri(),
                                dateField.getType(),
                                new CascadeType[]{});
+        final Field characterField = OWLClassM.getCharacterAttributeField();
+        final FieldSpecification<? super OWLClassM, ?> characterAtt = et.getFieldSpecification(characterField.getName());
+        checkSingularAttribute(characterAtt, et, characterField.getName(), Attribute.PersistentAttributeType.DATA, characterField,
+                FetchType.EAGER, false, characterField.getAnnotation(OWLDataProperty.class).iri(),
+                characterField.getType(),
+                new CascadeType[]{});
         final Field enumField = OWLClassM.getEnumAttributeField();
         final FieldSpecification<? super OWLClassM, ?> enumAtt = et.getFieldSpecification(enumField.getName());
         checkSingularAttribute(enumAtt, et, enumField.getName(), Attribute.PersistentAttributeType.DATA, enumField,

--- a/jopa-impl/src/test/java/cz/cvut/kbss/jopa/model/metamodel/ConverterResolverTest.java
+++ b/jopa-impl/src/test/java/cz/cvut/kbss/jopa/model/metamodel/ConverterResolverTest.java
@@ -45,10 +45,12 @@ import cz.cvut.kbss.jopa.oom.converter.ToIntegerConverter;
 import cz.cvut.kbss.jopa.oom.converter.ToLexicalFormConverter;
 import cz.cvut.kbss.jopa.oom.converter.ToMultilingualStringConverter;
 import cz.cvut.kbss.jopa.oom.converter.ToRdfLiteralConverter;
+import cz.cvut.kbss.jopa.oom.converter.CharacterConverter;
 import cz.cvut.kbss.jopa.oom.converter.datetime.DateConverter;
 import cz.cvut.kbss.jopa.oom.converter.datetime.InstantConverter;
 import cz.cvut.kbss.jopa.utils.Configuration;
 import cz.cvut.kbss.jopa.vocabulary.XSD;
+import cz.cvut.kbss.ontodriver.model.LangString;
 import cz.cvut.kbss.ontodriver.model.Literal;
 import cz.cvut.kbss.ontodriver.model.NamedResource;
 import org.junit.jupiter.api.Test;
@@ -108,6 +110,18 @@ class ConverterResolverTest {
         assertTrue(result.isPresent());
         assertTrue(result.get().supportsAxiomValueType(Literal.class));
         assertThat(result.get(), instanceOf(DateConverter.class));
+    }
+
+    @Test
+    void resolveConverterReturnsBuiltInCharacterConverterForDataPropertyWithCharacterTarget() throws Exception {
+        final PropertyInfo propertyInfo = OWLClassM.getCharacterAttributeFieldPropertyInfo();
+        final PropertyAttributes pa = mock(PropertyAttributes.class);
+        when(pa.getPersistentAttributeType()).thenReturn(Attribute.PersistentAttributeType.DATA);
+        doReturn(BasicTypeImpl.get(Character.class)).when(pa).getType();
+        final Optional<ConverterWrapper<?, ?>> result = sut.resolveConverter(propertyInfo, pa);
+        assertTrue(result.isPresent());
+        assertTrue(result.get().supportsAxiomValueType(String.class));
+        assertThat(result.get(), instanceOf(CharacterConverter.class));
     }
 
     @Test

--- a/jopa-impl/src/test/java/cz/cvut/kbss/jopa/oom/EntityConstructorTest.java
+++ b/jopa-impl/src/test/java/cz/cvut/kbss/jopa/oom/EntityConstructorTest.java
@@ -500,7 +500,8 @@ class EntityConstructorTest {
         final Long lng = 365L;
         final Double d = 3.14;
         final Date date = new Date();
-        axioms.addAll(createAxiomsForValues(true, i, lng, d, date, null));
+        final Character character = 'j';
+        axioms.addAll(createAxiomsForValues(true, i, lng, d, date, character, null));
 
         final OWLClassM res = constructor.reconstructEntity(constructionConfig(ID, mocks.forOwlClassM()
                                                                                         .entityType(), descriptor), axioms);
@@ -509,9 +510,10 @@ class EntityConstructorTest {
         assertEquals(lng, res.getLongAttribute());
         assertEquals(d, res.getDoubleAttribute());
         assertEquals(date, res.getDateAttribute());
+        assertEquals(character, res.getCharacterAttribute());
     }
 
-    private Collection<Axiom<?>> createAxiomsForValues(Boolean b, Integer i, Long lng, Double d, Date date,
+    private Collection<Axiom<?>> createAxiomsForValues(Boolean b, Integer i, Long lng, Double d, Date date, Character character,
                                                        OWLClassM.Severity severity) throws
             Exception {
         final Collection<Axiom<?>> axioms = new ArrayList<>();
@@ -543,6 +545,12 @@ class EntityConstructorTest {
                     new AxiomImpl<>(ID_RESOURCE, Assertion.createDataPropertyAssertion(URI.create(dateAttIri), false),
                             new Value<>(date)));
         }
+        if (character != null) {
+            final String characterAttIri = OWLClassM.getCharacterAttributeField().getAnnotation(OWLDataProperty.class).iri();
+            axioms.add(
+                    new AxiomImpl<>(ID_RESOURCE, Assertion.createDataPropertyAssertion(URI.create(characterAttIri), false),
+                            new Value<>(character.toString())));
+        }
         if (severity != null) {
             final String enumAttIri = OWLClassM.getEnumAttributeField().getAnnotation(OWLDataProperty.class).iri();
             axioms.add(
@@ -557,7 +565,7 @@ class EntityConstructorTest {
         final Set<Axiom<?>> axioms = new HashSet<>();
         axioms.add(getClassAssertionAxiomForType(ID, OWLClassM.getClassIri()));
         final OWLClassM.Severity enumValue = OWLClassM.Severity.HIGH;
-        axioms.addAll(createAxiomsForValues(null, null, null, null, null, enumValue));
+        axioms.addAll(createAxiomsForValues(null, null, null, null, null, null, enumValue));
 
         final OWLClassM result = constructor
                 .reconstructEntity(constructionConfig(ID, mocks.forOwlClassM().entityType(), descriptor), axioms);

--- a/jopa-impl/src/test/java/cz/cvut/kbss/jopa/oom/EntityDeconstructorTest.java
+++ b/jopa-impl/src/test/java/cz/cvut/kbss/jopa/oom/EntityDeconstructorTest.java
@@ -372,6 +372,7 @@ class EntityDeconstructorTest {
         assertTrue(containsDPAssertion(res, OWLClassM.getDoubleAttributeField(), entityM.getDoubleAttribute()));
         assertTrue(containsDPAssertion(res, OWLClassM.getLongAttributeField(), entityM.getLongAttribute()));
         assertTrue(containsDPAssertion(res, OWLClassM.getDateAttributeField(), entityM.getDateAttribute()));
+        assertTrue(containsDPAssertion(res, OWLClassM.getCharacterAttributeField(), entityM.getCharacterAttribute().toString()));
     }
 
     private boolean containsInstanceClassAssertion(AxiomValueDescriptor descriptor, String classIri) {

--- a/jopa-impl/src/test/java/cz/cvut/kbss/jopa/oom/PluralAnnotationPropertyStrategyTest.java
+++ b/jopa-impl/src/test/java/cz/cvut/kbss/jopa/oom/PluralAnnotationPropertyStrategyTest.java
@@ -146,6 +146,7 @@ class PluralAnnotationPropertyStrategyTest {
         when(att.getCollectionType()).thenReturn(CollectionType.SET);
         when(att.getBindableJavaType()).thenReturn(elementType);
         when(att.getJavaField()).thenReturn(entity.getDeclaredField("sources"));
+        when(att.getJavaType()).thenReturn(Set.class);
         when(att.getIRI()).thenReturn(IRI.create(DC.Terms.SOURCE));
         when(att.getConverter()).thenReturn(converter);
         when(att.hasLanguage()).thenReturn(true);

--- a/jopa-impl/src/test/java/cz/cvut/kbss/jopa/oom/converter/CharacterConverterTest.java
+++ b/jopa-impl/src/test/java/cz/cvut/kbss/jopa/oom/converter/CharacterConverterTest.java
@@ -1,0 +1,32 @@
+/*
+ * JOPA
+ * Copyright (C) 2024 Czech Technical University in Prague
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package cz.cvut.kbss.jopa.oom.converter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CharacterConverterTest {
+
+    private final CharacterConverter converter = new CharacterConverter();
+
+    @Test
+    public void toAttributeSupportsIdentityConversion() {
+        assertEquals(Character.valueOf('j'), converter.convertToAttribute("j"));
+    }
+}

--- a/jopa-impl/src/test/java/cz/cvut/kbss/jopa/oom/converter/CharacterConverterTest.java
+++ b/jopa-impl/src/test/java/cz/cvut/kbss/jopa/oom/converter/CharacterConverterTest.java
@@ -17,9 +17,11 @@
  */
 package cz.cvut.kbss.jopa.oom.converter;
 
+import cz.cvut.kbss.jopa.datatype.exception.DatatypeMappingException;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class CharacterConverterTest {
 
@@ -28,5 +30,12 @@ class CharacterConverterTest {
     @Test
     public void toAttributeSupportsIdentityConversion() {
         assertEquals(Character.valueOf('j'), converter.convertToAttribute("j"));
+    }
+
+    @Test
+    public void toAttributeThrowsWhenValueIsTooLong() {
+        DatatypeMappingException thrown = assertThrows(DatatypeMappingException.class, () -> converter.convertToAttribute("abc"));
+
+        assertEquals(thrown.getMessage(), "Unable to map literal abc to java.lang.Character, because its length is greater than 1");
     }
 }

--- a/jopa-impl/src/test/java/cz/cvut/kbss/jopa/sessions/CloneBuilderTest.java
+++ b/jopa-impl/src/test/java/cz/cvut/kbss/jopa/sessions/CloneBuilderTest.java
@@ -536,6 +536,9 @@ public class CloneBuilderTest {
         m.setDateAttribute(new Date(System.currentTimeMillis() + 10000L));
         changeSet.addChangeRecord(
                 new ChangeRecord(metamodelMocks.forOwlClassM().dateAttribute(), m.getDateAttribute()));
+        m.setCharacterAttribute('w');
+        changeSet.addChangeRecord(
+                new ChangeRecord(metamodelMocks.forOwlClassM().characterAttribute(), m.getCharacterAttribute()));
 
         builder.mergeChanges(changeSet);
         assertEquals(m.getBooleanAttribute(), entityM.getBooleanAttribute());
@@ -543,6 +546,7 @@ public class CloneBuilderTest {
         assertEquals(m.getLongAttribute(), entityM.getLongAttribute());
         assertEquals(m.getDoubleAttribute(), entityM.getDoubleAttribute());
         assertEquals(m.getDateAttribute(), entityM.getDateAttribute());
+        assertEquals(m.getCharacterAttribute(), entityM.getCharacterAttribute());
     }
 
     @Test

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/OWLClassBB.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/OWLClassBB.java
@@ -49,6 +49,9 @@ public class OWLClassBB implements HasUri {
     @OWLDataProperty(iri = Vocabulary.P_BB_DOUBLE_ATTRIBUTE)
     private double doubleAttribute;
 
+    @OWLDataProperty(iri = Vocabulary.P_BB_CHAR_ATTRIBUTE)
+    private char charAttribute;
+
     public OWLClassBB() {
     }
 
@@ -121,6 +124,14 @@ public class OWLClassBB implements HasUri {
         this.booleanAttribute = booleanAttribute;
     }
 
+    public char getCharAttribute() {
+        return charAttribute;
+    }
+
+    public void setCharAttribute(char charAttribute) {
+        this.charAttribute = charAttribute;
+    }
+
     @Override
     public String toString() {
         return "OWLClassBB{" +
@@ -132,6 +143,7 @@ public class OWLClassBB implements HasUri {
                 ", longAttribute=" + longAttribute +
                 ", floatAttribute=" + floatAttribute +
                 ", doubleAttribute=" + doubleAttribute +
+                ", charAttribute=" + charAttribute +
                 '}';
     }
 }

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/OWLClassBB.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/OWLClassBB.java
@@ -1,0 +1,137 @@
+/*
+ * JOPA
+ * Copyright (C) 2024 Czech Technical University in Prague
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package cz.cvut.kbss.jopa.test;
+
+import cz.cvut.kbss.jopa.model.annotations.Id;
+import cz.cvut.kbss.jopa.model.annotations.OWLClass;
+import cz.cvut.kbss.jopa.model.annotations.OWLDataProperty;
+
+import java.net.URI;
+
+@OWLClass(iri = Vocabulary.C_OWL_CLASS_BB)
+public class OWLClassBB implements HasUri {
+    @Id
+    private URI uri;
+
+    @OWLDataProperty(iri = Vocabulary.P_BB_INT_ATTRIBUTE)
+    private int intAttribute;
+
+    @OWLDataProperty(iri = Vocabulary.P_BB_BOOLEAN_ATTRIBUTE)
+    private boolean booleanAttribute;
+
+    @OWLDataProperty(iri = Vocabulary.P_BB_BYTE_ATTRIBUTE)
+    private byte byteAttribute;
+
+    @OWLDataProperty(iri = Vocabulary.P_BB_SHORT_ATTRIBUTE)
+    private short shortAttribute;
+
+    @OWLDataProperty(iri = Vocabulary.P_BB_LONG_ATTRIBUTE)
+    private long longAttribute;
+
+    @OWLDataProperty(iri = Vocabulary.P_BB_FLOAT_ATTRIBUTE)
+    private float floatAttribute;
+
+    @OWLDataProperty(iri = Vocabulary.P_BB_DOUBLE_ATTRIBUTE)
+    private double doubleAttribute;
+
+    public OWLClassBB() {
+    }
+
+    public OWLClassBB(URI uri) {
+        this.uri = uri;
+    }
+
+    public void setUri(URI uri) {
+        this.uri = uri;
+    }
+
+    @Override
+    public URI getUri() {
+        return uri;
+    }
+
+    public int getIntAttribute() {
+        return intAttribute;
+    }
+
+    public void setIntAttribute(int intAttribute) {
+        this.intAttribute = intAttribute;
+    }
+
+    public byte getByteAttribute() {
+        return byteAttribute;
+    }
+
+    public void setByteAttribute(byte byteAttribute) {
+        this.byteAttribute = byteAttribute;
+    }
+
+    public double getDoubleAttribute() {
+        return doubleAttribute;
+    }
+
+    public void setDoubleAttribute(double doubleAttribute) {
+        this.doubleAttribute = doubleAttribute;
+    }
+
+    public float getFloatAttribute() {
+        return floatAttribute;
+    }
+
+    public void setFloatAttribute(float floatAttribute) {
+        this.floatAttribute = floatAttribute;
+    }
+
+    public long getLongAttribute() {
+        return longAttribute;
+    }
+
+    public void setLongAttribute(long longAttribute) {
+        this.longAttribute = longAttribute;
+    }
+
+    public short getShortAttribute() {
+        return shortAttribute;
+    }
+
+    public void setShortAttribute(short shortAttribute) {
+        this.shortAttribute = shortAttribute;
+    }
+
+    public boolean getBooleanAttribute() {
+        return booleanAttribute;
+    }
+
+    public void setBooleanAttribute(boolean booleanAttribute) {
+        this.booleanAttribute = booleanAttribute;
+    }
+
+    @Override
+    public String toString() {
+        return "OWLClassBB{" +
+                "uri=" + uri +
+                ", intAttribute=" + intAttribute +
+                ", booleanAttribute=" + booleanAttribute +
+                ", byteAttribute=" + byteAttribute +
+                ", shortAttribute=" + shortAttribute +
+                ", longAttribute=" + longAttribute +
+                ", floatAttribute=" + floatAttribute +
+                ", doubleAttribute=" + doubleAttribute +
+                '}';
+    }
+}

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/OWLClassM.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/OWLClassM.java
@@ -58,6 +58,9 @@ public class OWLClassM {
     @OWLDataProperty(iri = Vocabulary.p_m_dateAttribute)
     private Date dateAttribute;
 
+    @OWLDataProperty(iri = Vocabulary.p_m_characterAttribute)
+    private Character characterAttribute;
+
     @OWLDataProperty(iri = Vocabulary.p_m_enumAttribute)
     private Severity enumAttribute;
 
@@ -162,6 +165,14 @@ public class OWLClassM {
 
     public void setDateAttribute(Date dateAttribute) {
         this.dateAttribute = dateAttribute;
+    }
+
+    public Character getCharacterAttribute() {
+        return characterAttribute;
+    }
+
+    public void setCharacterAttribute(Character characterAttribute) {
+        this.characterAttribute = characterAttribute;
     }
 
     public Severity getEnumAttribute() {
@@ -286,6 +297,8 @@ public class OWLClassM {
                 ", longAttribute=" + longAttribute +
                 ", floatAttribute=" + floatAttribute +
                 ", doubleAttribute=" + doubleAttribute +
+                ", dateAttribute=" + dateAttribute +
+                ", characterAttribute" + characterAttribute +
                 ", enumAttribute=" + enumAttribute +
                 ", ordinalEnumAttribute=" + ordinalEnumAttribute +
                 ", integerSet=" + integerSet +
@@ -313,6 +326,7 @@ public class OWLClassM {
         this.floatAttribute = 3.14F;
         this.doubleAttribute = 3.14D;
         this.dateAttribute = new Date();
+        this.characterAttribute = 'j';
         this.enumAttribute = Severity.MEDIUM;
         this.ordinalEnumAttribute = enumAttribute;
         this.integerSet = IntStream.generate(Generators::randomInt).limit(10).boxed().collect(Collectors.toSet());

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/Vocabulary.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/Vocabulary.java
@@ -61,6 +61,7 @@ public class Vocabulary {
     public static final String C_OWL_CLASS_Y = CLASS_IRI_BASE + "OWLClassY";
     public static final String C_OWL_CLASS_Z = CLASS_IRI_BASE + "OWLClassZ";
     public static final String C_OWL_CLASS_PART_CONSTR_IN_PARENT = CLASS_IRI_BASE + "OWLClassWithPartConstraintsInInterfaceParent";
+    public static final String C_OWL_CLASS_BB = CLASS_IRI_BASE + "OWLClassBB";
     public static final String C_OWL_CLASS_Z_CHILD = CLASS_IRI_BASE + "OWLClassZChild";
     public static final String C_OwlClassWithQueryAttr = CLASS_IRI_BASE + "OWLClassWithQueryAttr";
     public static final String C_OwlClassWithQueryAttr2 = CLASS_IRI_BASE + "OWLClassWithQueryAttr2";
@@ -149,6 +150,15 @@ public class Vocabulary {
     public static final String P_Y_PLURAL_MULTILINGUAL_ATTRIBUTE = ATTRIBUTE_IRI_BASE + "yPluralMultilingual";
 
     public static final String P_AA_DYNAMIC_ATTRIBUTE = ATTRIBUTE_IRI_BASE + "aaDynamicAttribute";
+    public static final String P_BB_INT_ATTRIBUTE = ATTRIBUTE_IRI_BASE + "bbIntAttribute";
+    public static final String P_BB_BOOLEAN_ATTRIBUTE = ATTRIBUTE_IRI_BASE + "bbBooleanAttribute";
+    public static final String P_BB_BYTE_ATTRIBUTE = ATTRIBUTE_IRI_BASE + "bbByteAttribute";
+    public static final String P_BB_SHORT_ATTRIBUTE = ATTRIBUTE_IRI_BASE + "bbShortAttribute";
+    public static final String P_BB_LONG_ATTRIBUTE = ATTRIBUTE_IRI_BASE + "bbLongAttribute";
+    public static final String P_BB_FLOAT_ATTRIBUTE = ATTRIBUTE_IRI_BASE + "bbFloatAttribute";
+    public static final String P_BB_DOUBLE_ATTRIBUTE = ATTRIBUTE_IRI_BASE + "bbDoubleAttribute";
+    public static final String P_BB_CHAR_ATTRIBUTE = ATTRIBUTE_IRI_BASE + "bbCharAttribute";
+
 
     public static final String P_HAS_H = ATTRIBUTE_IRI_BASE + "hasH";
 

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/Vocabulary.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/Vocabulary.java
@@ -88,6 +88,7 @@ public class Vocabulary {
     public static final String p_m_doubleAttribute = ATTRIBUTE_IRI_BASE + "m-doubleAttribute";
     public static final String p_m_floatAttribute = ATTRIBUTE_IRI_BASE + "m-floatAttribute";
     public static final String p_m_dateAttribute = ATTRIBUTE_IRI_BASE + "m-dateAttribute";
+    public static final String p_m_characterAttribute = ATTRIBUTE_IRI_BASE + "m-characterAttribute";
     public static final String p_m_enumAttribute = ATTRIBUTE_IRI_BASE + "m-enumAttribute";
     public static final String p_m_ordinalEnumAttribute = ATTRIBUTE_IRI_BASE + "m-ordinalEnumAttribute";
     public static final String p_m_enumSimpleLiteralAttribute = ATTRIBUTE_IRI_BASE + "m-enumSimpleLiteralAttribute";

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/BaseRunner.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/BaseRunner.java
@@ -191,6 +191,7 @@ public abstract class BaseRunner {
         entityBB.setLongAttribute(20L);
         entityBB.setFloatAttribute(25.5f);
         entityBB.setDoubleAttribute(30.7d);
+        entityBB.setCharAttribute('j');
     }
 
     @AfterEach

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/BaseRunner.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/BaseRunner.java
@@ -23,6 +23,7 @@ import cz.cvut.kbss.jopa.model.metamodel.FieldSpecification;
 import cz.cvut.kbss.jopa.test.OWLClassA;
 import cz.cvut.kbss.jopa.test.OWLClassAA;
 import cz.cvut.kbss.jopa.test.OWLClassB;
+import cz.cvut.kbss.jopa.test.OWLClassBB;
 import cz.cvut.kbss.jopa.test.OWLClassC;
 import cz.cvut.kbss.jopa.test.OWLClassD;
 import cz.cvut.kbss.jopa.test.OWLClassE;
@@ -95,6 +96,8 @@ public abstract class BaseRunner {
     protected OWLClassWithQueryAttr7 entityWithQueryAttr7;
     // Dynamic attributes
     protected OWLClassAA entityAA;
+    // Primitive attributes
+    protected OWLClassBB entityBB;
 
     protected final DataAccessor dataAccessor;
     protected final PersistenceFactory persistenceFactory;
@@ -179,6 +182,15 @@ public abstract class BaseRunner {
         entityWithQueryAttr7.setUri(URI.create("http://krizik.felk.cvut.cz/ontologies/jopa/tests/entityWithQueryAttr7"));
         this.entityAA = new OWLClassAA();
         this.entityAA.setUri(URI.create("http://krizik.felk.cvut.cz/ontologies/jopa/tests/entityAA"));
+        this.entityBB = new OWLClassBB();
+        this.entityBB.setUri(URI.create("http://krizik.felk.cvut.cz/ontologies/jopa/tests/entityBB"));
+        entityBB.setIntAttribute(15);
+        entityBB.setBooleanAttribute(true);
+        entityBB.setByteAttribute((byte) 5);
+        entityBB.setShortAttribute((short) 10);
+        entityBB.setLongAttribute(20L);
+        entityBB.setFloatAttribute(25.5f);
+        entityBB.setDoubleAttribute(30.7d);
     }
 
     @AfterEach

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/CreateOperationsRunner.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/CreateOperationsRunner.java
@@ -261,6 +261,7 @@ public abstract class CreateOperationsRunner extends BaseRunner {
         assertEquals(entityBB.getLongAttribute(), res.getLongAttribute());
         assertEquals(entityBB.getFloatAttribute(), res.getFloatAttribute());
         assertEquals(entityBB.getDoubleAttribute(), res.getDoubleAttribute());
+        assertEquals(entityBB.getCharAttribute(), res.getCharAttribute());
     }
 
     @Test

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/CreateOperationsRunner.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/CreateOperationsRunner.java
@@ -243,6 +243,7 @@ public abstract class CreateOperationsRunner extends BaseRunner {
         assertEquals(entityM.getFloatAttribute(), res.getFloatAttribute());
         assertEquals(entityM.getDoubleAttribute(), res.getDoubleAttribute());
         assertEquals(entityM.getDateAttribute(), res.getDateAttribute());
+        assertEquals(entityM.getCharacterAttribute(), res.getCharacterAttribute());
     }
 
     @Test

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/CreateOperationsRunner.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/CreateOperationsRunner.java
@@ -25,6 +25,7 @@ import cz.cvut.kbss.jopa.model.descriptors.Descriptor;
 import cz.cvut.kbss.jopa.model.descriptors.EntityDescriptor;
 import cz.cvut.kbss.jopa.test.OWLClassA;
 import cz.cvut.kbss.jopa.test.OWLClassB;
+import cz.cvut.kbss.jopa.test.OWLClassBB;
 import cz.cvut.kbss.jopa.test.OWLClassD;
 import cz.cvut.kbss.jopa.test.OWLClassE;
 import cz.cvut.kbss.jopa.test.OWLClassG;
@@ -242,6 +243,23 @@ public abstract class CreateOperationsRunner extends BaseRunner {
         assertEquals(entityM.getFloatAttribute(), res.getFloatAttribute());
         assertEquals(entityM.getDoubleAttribute(), res.getDoubleAttribute());
         assertEquals(entityM.getDateAttribute(), res.getDateAttribute());
+    }
+
+    @Test
+    void testPersistEntityWithBasicPrimitiveTypeAttributes() {
+        this.em = getEntityManager("PersistEntityWithBasicPrimitiveTypeAttributes", false);
+        persist(entityBB);
+        em.clear();
+
+        final OWLClassBB res = findRequired(OWLClassBB.class, entityBB.getUri());
+        assertEquals(entityBB.getUri(), res.getUri());
+        assertEquals(entityBB.getIntAttribute(), res.getIntAttribute());
+        assertEquals(entityBB.getBooleanAttribute(), res.getBooleanAttribute());
+        assertEquals(entityBB.getByteAttribute(), res.getByteAttribute());
+        assertEquals(entityBB.getShortAttribute(), res.getShortAttribute());
+        assertEquals(entityBB.getLongAttribute(), res.getLongAttribute());
+        assertEquals(entityBB.getFloatAttribute(), res.getFloatAttribute());
+        assertEquals(entityBB.getDoubleAttribute(), res.getDoubleAttribute());
     }
 
     @Test

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/RetrieveOperationsRunner.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/RetrieveOperationsRunner.java
@@ -124,6 +124,7 @@ public abstract class RetrieveOperationsRunner extends BaseRunner {
         assertEquals(entityBB.getLongAttribute(), res.getLongAttribute());
         assertEquals(entityBB.getFloatAttribute(), res.getFloatAttribute());
         assertEquals(entityBB.getDoubleAttribute(), res.getDoubleAttribute());
+        assertEquals(entityBB.getCharAttribute(), res.getCharAttribute());
         assertTrue(em.contains(res));
     }
 
@@ -147,6 +148,7 @@ public abstract class RetrieveOperationsRunner extends BaseRunner {
         assertEquals(0L, res.getLongAttribute());
         assertEquals(0.0f, res.getFloatAttribute());
         assertEquals(0.0d, res.getDoubleAttribute());
+        assertEquals('\u0000', res.getCharAttribute());
         assertTrue(em.contains(res));
     }
 

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/RetrieveOperationsRunner.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/RetrieveOperationsRunner.java
@@ -446,6 +446,7 @@ public abstract class RetrieveOperationsRunner extends BaseRunner {
         assertEquals(entityM.getIntAttribute(), result.getIntAttribute());
         assertEquals(entityM.getIntegerSet(), result.getIntegerSet());
         assertEquals(entityM.getDateAttribute(), result.getDateAttribute());
+        assertEquals(entityM.getCharacterAttribute(), result.getCharacterAttribute());
         assertEquals(entityM.getEnumAttribute(), result.getEnumAttribute());
     }
 

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/RetrieveOperationsRunner.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/RetrieveOperationsRunner.java
@@ -18,6 +18,7 @@
 package cz.cvut.kbss.jopa.test.runner;
 
 import cz.cvut.kbss.jopa.model.JOPAPersistenceProperties;
+import cz.cvut.kbss.jopa.model.SequencesVocabulary;
 import cz.cvut.kbss.jopa.model.descriptors.Descriptor;
 import cz.cvut.kbss.jopa.model.descriptors.EntityDescriptor;
 import cz.cvut.kbss.jopa.model.query.TypedQuery;
@@ -25,6 +26,7 @@ import cz.cvut.kbss.jopa.proxy.lazy.LazyLoadingProxy;
 import cz.cvut.kbss.jopa.test.OWLClassA;
 import cz.cvut.kbss.jopa.test.OWLClassAA;
 import cz.cvut.kbss.jopa.test.OWLClassB;
+import cz.cvut.kbss.jopa.test.OWLClassBB;
 import cz.cvut.kbss.jopa.test.OWLClassC;
 import cz.cvut.kbss.jopa.test.OWLClassD;
 import cz.cvut.kbss.jopa.test.OWLClassE;
@@ -69,6 +71,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -103,6 +106,47 @@ public abstract class RetrieveOperationsRunner extends BaseRunner {
         assertEquals(entityA.getUri(), res.getUri());
         assertEquals(entityA.getStringAttribute(), res.getStringAttribute());
         assertTrue(entityA.getTypes().containsAll(res.getTypes()));
+        assertTrue(em.contains(res));
+    }
+
+    @Test
+    void testRetrievePrimitive() {
+        this.em = getEntityManager("RetrieveSimplePrimitive", false);
+        persist(entityBB);
+
+        em.getEntityManagerFactory().getCache().evictAll();
+        final OWLClassBB res = findRequired(OWLClassBB.class, entityBB.getUri());
+        assertEquals(entityBB.getUri(), res.getUri());
+        assertEquals(entityBB.getIntAttribute(), res.getIntAttribute());
+        assertEquals(entityBB.getBooleanAttribute(), res.getBooleanAttribute());
+        assertEquals(entityBB.getByteAttribute(), res.getByteAttribute());
+        assertEquals(entityBB.getShortAttribute(), res.getShortAttribute());
+        assertEquals(entityBB.getLongAttribute(), res.getLongAttribute());
+        assertEquals(entityBB.getFloatAttribute(), res.getFloatAttribute());
+        assertEquals(entityBB.getDoubleAttribute(), res.getDoubleAttribute());
+        assertTrue(em.contains(res));
+    }
+
+    @Test
+    void testRetrieveMissingPrimitive() throws Exception {
+        this.em = getEntityManager("RetrieveSimplePrimitive", false);
+        final List<Quad> data = new ArrayList<>(List.of(
+                new Quad(entityBB.getUri(), URI.create(RDF.TYPE), URI.create(Vocabulary.C_OWL_CLASS_BB))
+        ));
+        persistTestData(data, em);
+
+        em.getEntityManagerFactory().getCache().evictAll();
+        final OWLClassBB res = findRequired(OWLClassBB.class, entityBB.getUri());
+
+        // if primitives are not set, they should fall back to their default values
+        assertEquals(entityBB.getUri(), res.getUri());
+        assertEquals(0, res.getIntAttribute());
+        assertEquals(false, res.getBooleanAttribute());
+        assertEquals(0, res.getByteAttribute());
+        assertEquals((short) 0, res.getShortAttribute());
+        assertEquals(0L, res.getLongAttribute());
+        assertEquals(0.0f, res.getFloatAttribute());
+        assertEquals(0.0d, res.getDoubleAttribute());
         assertTrue(em.contains(res));
     }
 

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/RetrieveOperationsRunner.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/RetrieveOperationsRunner.java
@@ -47,9 +47,12 @@ import cz.cvut.kbss.jopa.test.environment.DataAccessor;
 import cz.cvut.kbss.jopa.test.environment.Generators;
 import cz.cvut.kbss.jopa.test.environment.PersistenceFactory;
 import cz.cvut.kbss.jopa.test.environment.Quad;
+import cz.cvut.kbss.jopa.test.environment.TestEnvironment;
 import cz.cvut.kbss.jopa.vocabulary.RDF;
+import cz.cvut.kbss.jopa.vocabulary.XSD;
 import cz.cvut.kbss.ontodriver.ReloadableDataSource;
 import cz.cvut.kbss.ontodriver.config.OntoDriverProperties;
+import cz.cvut.kbss.ontodriver.model.Literal;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 
@@ -110,9 +113,27 @@ public abstract class RetrieveOperationsRunner extends BaseRunner {
     }
 
     @Test
-    void testRetrievePrimitive() {
+    void testRetrievePrimitive() throws Exception {
         this.em = getEntityManager("RetrieveSimplePrimitive", false);
-        persist(entityBB);
+        persistTestData(Arrays.asList(
+                new Quad(entityBB.getUri(), URI.create(RDF.TYPE), URI.create(Vocabulary.C_OWL_CLASS_BB)),
+                new Quad(entityBB.getUri(), URI.create(Vocabulary.P_BB_INT_ATTRIBUTE),
+                        new Literal("15", XSD.INT)),
+                new Quad(entityBB.getUri(), URI.create(Vocabulary.P_BB_BOOLEAN_ATTRIBUTE),
+                        new Literal("true", XSD.BOOLEAN)),
+                new Quad(entityBB.getUri(), URI.create(Vocabulary.P_BB_BYTE_ATTRIBUTE),
+                        new Literal("5", XSD.BYTE)),
+                new Quad(entityBB.getUri(), URI.create(Vocabulary.P_BB_SHORT_ATTRIBUTE),
+                        new Literal("10", XSD.SHORT)),
+                new Quad(entityBB.getUri(), URI.create(Vocabulary.P_BB_LONG_ATTRIBUTE),
+                        new Literal("20", XSD.LONG)),
+                new Quad(entityBB.getUri(), URI.create(Vocabulary.P_BB_FLOAT_ATTRIBUTE),
+                        new Literal("25.5", XSD.FLOAT)),
+                new Quad(entityBB.getUri(), URI.create(Vocabulary.P_BB_DOUBLE_ATTRIBUTE),
+                        new Literal("30.7", XSD.DOUBLE)),
+                new Quad(entityBB.getUri(), URI.create(Vocabulary.P_BB_CHAR_ATTRIBUTE),
+                        new Literal("j", XSD.STRING))
+        ), em);
 
         em.getEntityManagerFactory().getCache().evictAll();
         final OWLClassBB res = findRequired(OWLClassBB.class, entityBB.getUri());

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/UpdateOperationsOnGetReferenceRunner.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/UpdateOperationsOnGetReferenceRunner.java
@@ -79,6 +79,7 @@ public abstract class UpdateOperationsOnGetReferenceRunner extends BaseRunner {
         assertEquals(entityM.getBooleanAttribute(), result.getBooleanAttribute());
         assertEquals(entityM.getEnumAttribute(), result.getEnumAttribute());
         assertEquals(entityM.getDateAttribute(), result.getDateAttribute());
+        assertEquals(entityM.getCharacterAttribute(), result.getCharacterAttribute());
         assertEquals(entityM.getDoubleAttribute(), result.getDoubleAttribute());
     }
 

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/UpdateOperationsRunner.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/UpdateOperationsRunner.java
@@ -49,6 +49,7 @@ import cz.cvut.kbss.jopa.test.environment.Generators;
 import cz.cvut.kbss.jopa.test.environment.PersistenceFactory;
 import cz.cvut.kbss.jopa.test.environment.Quad;
 import cz.cvut.kbss.jopa.test.environment.TestEnvironmentUtils;
+import cz.cvut.kbss.jopa.vocabulary.RDF;
 import cz.cvut.kbss.jopa.vocabulary.XSD;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -1063,6 +1064,7 @@ public abstract class UpdateOperationsRunner extends BaseRunner {
         entityBB.setLongAttribute(20L);
         entityBB.setFloatAttribute(25.5f);
         entityBB.setDoubleAttribute(30.7);
+        entityBB.setCharAttribute('c');
         persist(entityBB);
 
         final int newIntValue = 20;
@@ -1072,6 +1074,7 @@ public abstract class UpdateOperationsRunner extends BaseRunner {
         final long newLongValue = 9L;
         final float newFloatValue = 3.2f;
         final double newDoubleValue = 8.9d;
+        final char newCharValue = 'o';
 
         em.getTransaction().begin();
         final OWLClassBB toUpdate = findRequired(OWLClassBB.class, entityBB.getUri());
@@ -1082,6 +1085,7 @@ public abstract class UpdateOperationsRunner extends BaseRunner {
         toUpdate.setLongAttribute(newLongValue);
         toUpdate.setFloatAttribute(newFloatValue);
         toUpdate.setDoubleAttribute(newDoubleValue);
+        toUpdate.setCharAttribute(newCharValue);
         em.getTransaction().commit();
 
         verifyValueDatatype(entityBB.getUri(), Vocabulary.P_BB_INT_ATTRIBUTE, XSD.INT);
@@ -1091,6 +1095,7 @@ public abstract class UpdateOperationsRunner extends BaseRunner {
         verifyValueDatatype(entityBB.getUri(), Vocabulary.P_BB_LONG_ATTRIBUTE, XSD.LONG);
         verifyValueDatatype(entityBB.getUri(), Vocabulary.P_BB_FLOAT_ATTRIBUTE, XSD.FLOAT);
         verifyValueDatatype(entityBB.getUri(), Vocabulary.P_BB_DOUBLE_ATTRIBUTE, XSD.DOUBLE);
+        verifyValueDatatype(entityBB.getUri(), Vocabulary.P_BB_CHAR_ATTRIBUTE, XSD.STRING);
         final OWLClassBB res = findRequired(OWLClassBB.class, entityBB.getUri());
         assertEquals(entityBB.getUri(), res.getUri());
         assertEquals(newIntValue, res.getIntAttribute());
@@ -1100,6 +1105,7 @@ public abstract class UpdateOperationsRunner extends BaseRunner {
         assertEquals(newLongValue, res.getLongAttribute());
         assertEquals(newFloatValue, res.getFloatAttribute());
         assertEquals(newDoubleValue, res.getDoubleAttribute());
+        assertEquals(newCharValue, res.getCharAttribute());
     }
 
 

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/UpdateOperationsRunner.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/UpdateOperationsRunner.java
@@ -407,6 +407,7 @@ public abstract class UpdateOperationsRunner extends BaseRunner {
         m.setDoubleAttribute(m.getDoubleAttribute() - 100.0);
         m.setLongAttribute(m.getLongAttribute() + 100L);
         m.setDateAttribute(new Date(System.currentTimeMillis() + 10000));
+        m.setCharacterAttribute('o');
         em.getTransaction().commit();
 
         final OWLClassM res = findRequired(OWLClassM.class, entityM.getKey());
@@ -415,6 +416,7 @@ public abstract class UpdateOperationsRunner extends BaseRunner {
         assertEquals(m.getFloatAttribute(), res.getFloatAttribute());
         assertEquals(m.getDoubleAttribute(), res.getDoubleAttribute());
         assertEquals(m.getDateAttribute(), res.getDateAttribute());
+        assertEquals(m.getCharacterAttribute(), res.getCharacterAttribute());
     }
 
     @Test

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/UpdateOperationsRunner.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/UpdateOperationsRunner.java
@@ -27,6 +27,7 @@ import cz.cvut.kbss.jopa.proxy.lazy.LazyLoadingProxy;
 import cz.cvut.kbss.jopa.test.OWLClassA;
 import cz.cvut.kbss.jopa.test.OWLClassAA;
 import cz.cvut.kbss.jopa.test.OWLClassB;
+import cz.cvut.kbss.jopa.test.OWLClassBB;
 import cz.cvut.kbss.jopa.test.OWLClassD;
 import cz.cvut.kbss.jopa.test.OWLClassE;
 import cz.cvut.kbss.jopa.test.OWLClassG;
@@ -1049,6 +1050,56 @@ public abstract class UpdateOperationsRunner extends BaseRunner {
 
         updateSimpleLiteralAndVerify();
     }
+
+    @Test
+    void updateSupportsUpdatingPrimitiveLiteralValue() {
+        this.em = getEntityManager("updateSupportsUpdatingSimpleLiteralValue", true);
+        entityBB.setIntAttribute(15);
+        entityBB.setBooleanAttribute(true);
+        entityBB.setByteAttribute((byte) 5);
+        entityBB.setShortAttribute((short) 10);
+        entityBB.setLongAttribute(20L);
+        entityBB.setFloatAttribute(25.5f);
+        entityBB.setDoubleAttribute(30.7);
+        persist(entityBB);
+
+        final int newIntValue = 20;
+        final boolean newBooleanValue = false;
+        final byte newByteValue = (byte) 8;
+        final short newShortValue = (short) 7;
+        final long newLongValue = 9L;
+        final float newFloatValue = 3.2f;
+        final double newDoubleValue = 8.9d;
+
+        em.getTransaction().begin();
+        final OWLClassBB toUpdate = findRequired(OWLClassBB.class, entityBB.getUri());
+        toUpdate.setIntAttribute(newIntValue);
+        toUpdate.setBooleanAttribute(newBooleanValue);
+        toUpdate.setByteAttribute(newByteValue);
+        toUpdate.setShortAttribute(newShortValue);
+        toUpdate.setLongAttribute(newLongValue);
+        toUpdate.setFloatAttribute(newFloatValue);
+        toUpdate.setDoubleAttribute(newDoubleValue);
+        em.getTransaction().commit();
+
+        verifyValueDatatype(entityBB.getUri(), Vocabulary.P_BB_INT_ATTRIBUTE, XSD.INT);
+        verifyValueDatatype(entityBB.getUri(), Vocabulary.P_BB_BOOLEAN_ATTRIBUTE, XSD.BOOLEAN);
+        verifyValueDatatype(entityBB.getUri(), Vocabulary.P_BB_BYTE_ATTRIBUTE, XSD.BYTE);
+        verifyValueDatatype(entityBB.getUri(), Vocabulary.P_BB_SHORT_ATTRIBUTE, XSD.SHORT);
+        verifyValueDatatype(entityBB.getUri(), Vocabulary.P_BB_LONG_ATTRIBUTE, XSD.LONG);
+        verifyValueDatatype(entityBB.getUri(), Vocabulary.P_BB_FLOAT_ATTRIBUTE, XSD.FLOAT);
+        verifyValueDatatype(entityBB.getUri(), Vocabulary.P_BB_DOUBLE_ATTRIBUTE, XSD.DOUBLE);
+        final OWLClassBB res = findRequired(OWLClassBB.class, entityBB.getUri());
+        assertEquals(entityBB.getUri(), res.getUri());
+        assertEquals(newIntValue, res.getIntAttribute());
+        assertEquals(newBooleanValue, res.getBooleanAttribute());
+        assertEquals(newByteValue, res.getByteAttribute());
+        assertEquals(newShortValue, res.getShortAttribute());
+        assertEquals(newLongValue, res.getLongAttribute());
+        assertEquals(newFloatValue, res.getFloatAttribute());
+        assertEquals(newDoubleValue, res.getDoubleAttribute());
+    }
+
 
     private void updateSimpleLiteralAndVerify() {
         em.getTransaction().begin();

--- a/jopa-owlapi-utils/src/main/java/cz/cvut/kbss/jopa/owlapi/DatatypeTransformer.java
+++ b/jopa-owlapi-utils/src/main/java/cz/cvut/kbss/jopa/owlapi/DatatypeTransformer.java
@@ -122,6 +122,10 @@ public class DatatypeTransformer {
             return DATA_FACTORY.getOWLLiteral(value.toString(), OWL2Datatype.XSD_INTEGER);
         } else if (value instanceof Long) {
             return DATA_FACTORY.getOWLLiteral(value.toString(), OWL2Datatype.XSD_LONG);
+        } else if (value instanceof Short) {
+            return DATA_FACTORY.getOWLLiteral(value.toString(), OWL2Datatype.XSD_SHORT);
+        } else if (value instanceof Byte) {
+            return DATA_FACTORY.getOWLLiteral(value.toString(), OWL2Datatype.XSD_BYTE);
         } else if (value instanceof Boolean) {
             return DATA_FACTORY.getOWLLiteral((Boolean) value);
         } else if (value instanceof Double) {

--- a/ontodriver-rdf4j/src/main/java/cz/cvut/kbss/ontodriver/rdf4j/util/Rdf4jUtils.java
+++ b/ontodriver-rdf4j/src/main/java/cz/cvut/kbss/ontodriver/rdf4j/util/Rdf4jUtils.java
@@ -108,6 +108,8 @@ public final class Rdf4jUtils {
 
         if (value instanceof Integer) {
             return vf.createLiteral((Integer) value);
+        } else if(value instanceof Character c) {
+            return vf.createLiteral(c.toString());
         } else if (value instanceof String) {
             return language != null ? vf.createLiteral((String) value, language) : vf.createLiteral((String) value);
         } else if (value instanceof LangString ls) {


### PR DESCRIPTION
This fixes #297 by adding support for primitive Java types like `int`, `short`, `boolean` and more.

- [x] Currently, `char` is unsupported, because  XSD does not include a char datatype. We could however probably implement it by mapping it to `XSD.STRING`
- [x] If the database is missing the value for a primitive type, an exception is thrown, because primitive types can not be set to `null`. I think this behavior is valid, because this state is only reachable if the database is mutated directly, but I would love to add a test for this - where would be a good place to do so?