### PR TITLE
Simplify SOQL grammar

### DIFF
--- a/jopa-impl/src/main/antlr4/cz/cvut/kbss/jopa/query/soql/Soql.g4
+++ b/jopa-impl/src/main/antlr4/cz/cvut/kbss/jopa/query/soql/Soql.g4
@@ -74,8 +74,8 @@ entityExpression
     ;
 
 comparisonExpression
-   : stringExpression COMPARISON_OPERATOR stringExpression
-   | simpleArithmeticExpression COMPARISON_OPERATOR simpleArithmeticExpression
+   : stringExpression comparisonOperator stringExpression
+   | simpleArithmeticExpression comparisonOperator simpleArithmeticExpression
    | entityExpression op=(EQUAL | NOT_EQUAL) ( entityExpression )
    ;
 
@@ -133,6 +133,14 @@ groupByItem: objectPathExpression ;
 
 inputParameter: COLON IDENTIFICATION_VARIABLE ;
 
+comparisonOperator
+    : op=EQUAL
+    | op='>'
+    | op='>='
+    | op='<'
+    | op='<='
+    | op=NOT_EQUAL
+    ;
 
 SELECT: 'SELECT' ;
 
@@ -170,7 +178,8 @@ IN: 'IN' ;
 
 MEMBER: 'MEMBER' ;
 
-COMPARISON_OPERATOR: '>' | '<' | '>=' | '<=' | '=' | '<>' | '!=' ;
+EQUAL: '=' ;
+NOT_EQUAL: '<>' | '!=' ;
 
 DOT: '.' ;
 

--- a/jopa-impl/src/main/antlr4/cz/cvut/kbss/jopa/query/soql/Soql.g4
+++ b/jopa-impl/src/main/antlr4/cz/cvut/kbss/jopa/query/soql/Soql.g4
@@ -16,21 +16,9 @@ selectClause: SELECT (DISTINCT)? selectItem (',' selectItem)* ;
 
 selectItem: selectExpression;
 
-selectExpression: param | count ;
+selectExpression: simplePath | aggregateExpression ;
 
-param: objWithAttr | objWithOutAttr ;
-
-objWithAttr: object DOT attribute;
-
-objWithOutAttr: object ;
-
-object: IDENTIFICATION_VARIABLE ;
-
-count: COUNT '(' param ')' ;
-
-attribute: IDENTIFICATION_VARIABLE ;
-
-joinedParams: object DOT attribute (DOT attribute)+ ;
+aggregateExpression: COUNT '(' (DISTINCT)? simplePath ')';
 
 fromClause: FROM entityName identificationVariable;
 
@@ -62,7 +50,7 @@ simpleConditionalExpression
    ;
 
 inExpression
-   : whereClauseParam (NOT)? IN '('? (inItem (',' inItem)*) ')'?
+   : simplePath (NOT)? IN '('? (inItem (',' inItem)*) ')'?
    ;
 
 inItem
@@ -79,21 +67,19 @@ likeExpression
    ;
 
 memberOfExpression
-    : inItem (NOT)? MEMBEROF whereClauseParam
+    : inItem (NOT)? MEMBER OF simplePath
     ;
 
 comparisonExpression
    : stringExpression COMPARISON_OPERATOR stringExpression
    | simpleArithmeticExpression COMPARISON_OPERATOR simpleArithmeticExpression
-   | whereClauseParam COMPARISON_OPERATOR ( whereClauseParam | whereClauseValue )
+   | simplePath COMPARISON_OPERATOR ( simplePath | whereClauseValue )
    ;
 
 whereClauseValue: (QMARK TEXT QMARK) | inputParameter ;
 
-whereClauseParam: param | joinedParams ;
-
 stringExpression
-   : whereClauseParam
+   : simplePath
    | inputParameter
    | functionsReturningStrings
    ;
@@ -103,7 +89,7 @@ functionsReturningStrings
    | 'SUBSTRING' '(' stringExpression ',' simpleArithmeticExpression ',' simpleArithmeticExpression ')'
    | 'LOWER' '(' stringExpression ')'
    | 'UPPER' '(' stringExpression ')'
-   | 'LANG' '(' whereClauseParam ')'
+   | 'LANG' '(' simplePath ')'
    ;
 
 simpleArithmeticExpression
@@ -119,7 +105,7 @@ arithmeticFactor
    ;
 
 arithmeticPrimary
-   : param
+   : simplePath
    | literal
    | '(' simpleArithmeticExpression ')'
    | inputParameter
@@ -161,6 +147,8 @@ OR: 'OR' ;
 
 BY: 'BY' ;
 
+OF: 'OF' ;
+
 ORDER: 'ORDER' ;
 
 GROUP: 'GROUP' ;
@@ -177,7 +165,7 @@ LIKE: 'LIKE' ;
 
 IN: 'IN' ;
 
-MEMBEROF: 'MEMBER OF' ;
+MEMBER: 'MEMBER' ;
 
 COMPARISON_OPERATOR: '>' | '<' | '>=' | '<=' | '=' | '<>' | '!=' ;
 

--- a/jopa-impl/src/main/antlr4/cz/cvut/kbss/jopa/query/soql/Soql.g4
+++ b/jopa-impl/src/main/antlr4/cz/cvut/kbss/jopa/query/soql/Soql.g4
@@ -70,10 +70,15 @@ memberOfExpression
     : inItem (NOT)? MEMBER OF simplePath
     ;
 
+entityExpression
+    : IDENTIFICATION_VARIABLE
+    | inputParameter
+    ;
+
 comparisonExpression
    : stringExpression COMPARISON_OPERATOR stringExpression
    | simpleArithmeticExpression COMPARISON_OPERATOR simpleArithmeticExpression
-   | simplePath COMPARISON_OPERATOR ( simplePath | whereClauseValue )
+   | entityExpression op=(EQUAL | NOT_EQUAL) ( entityExpression )
    ;
 
 whereClauseValue: (QMARK TEXT QMARK) | inputParameter ;
@@ -175,7 +180,19 @@ QMARK: '"' ;
 
 COLON: ':' ;
 
+TRUE: 'TRUE';
+
+FALSE: 'FALSE';
+
 IDENTIFICATION_VARIABLE: (LOWERCASE | UPPERCASE | '_') (LOWERCASE | UPPERCASE | DIGIT | '_')* ;
+
+STRING_LITERAL: QMARK TEXT QMARK ;
+
+INT_LITERAL: DIGIT+;
+
+FLOAT_LITERAL: DIGIT* '.' DIGIT;
+
+BOOLEAN_LITERAL: TRUE | FALSE;
 
 TEXT: (LOWERCASE | UPPERCASE | DIGIT)+ ;
 
@@ -184,9 +201,5 @@ UPPERCASE: ('A'..'Z');
 LOWERCASE: ('a'..'z');
 
 DIGIT: ('0'..'9');
-
-NUMBER: DIGIT+ ;
-
-VALUE: NUMBER ;
 
 WHITESPACE: (' ')+ -> skip;

--- a/jopa-impl/src/main/antlr4/cz/cvut/kbss/jopa/query/soql/Soql.g4
+++ b/jopa-impl/src/main/antlr4/cz/cvut/kbss/jopa/query/soql/Soql.g4
@@ -65,7 +65,7 @@ literal
    ;
 
 likeExpression
-   : stringExpression (NOT)? LIKE whereClauseValue
+   : stringExpression (NOT)? LIKE stringExpression
    ;
 
 memberOfExpression
@@ -83,10 +83,9 @@ comparisonExpression
    | entityExpression op=(EQUAL | NOT_EQUAL) ( entityExpression )
    ;
 
-whereClauseValue: (QMARK TEXT QMARK) | inputParameter ;
-
 stringExpression
    : simplePath
+   | STRING_LITERAL
    | inputParameter
    | functionsReturningStrings
    ;

--- a/jopa-impl/src/main/antlr4/cz/cvut/kbss/jopa/query/soql/Soql.g4
+++ b/jopa-impl/src/main/antlr4/cz/cvut/kbss/jopa/query/soql/Soql.g4
@@ -6,6 +6,12 @@ querySentence: selectStatement ;
 
 selectStatement: selectClause fromClause whereClause? groupByClause? orderByClause? ;
 
+objectPathExpression: simplePath DOT objectField ;
+
+simplePath: objectField (DOT simplePath)* ;
+
+objectField: IDENTIFICATION_VARIABLE ;
+
 selectClause: SELECT (DISTINCT)? selectItem (',' selectItem)* ;
 
 selectItem: selectExpression;
@@ -128,19 +134,13 @@ functionsReturningNumerics
    | 'FLOOR' '(' simpleArithmeticExpression ')'
    ;
 
-orderByClause: ORDERBY orderByFullFormComma orderByFullFormComma* ;
+orderByClause: ORDER BY orderByItem (',' orderByItem)* ;
 
-orderByFullFormComma: orderByFullForm ','? ;
+orderByItem: objectPathExpression (ASC | DESC) ;
 
-orderByFullForm: orderByParam ORDERING? ;
+groupByClause: GROUP BY groupByItem (',' groupByItem)* ;
 
-orderByParam: object DOT attribute (DOT attribute)* ;
-
-groupByClause: GROUPBY groupByParamComma groupByParamComma* ;
-
-groupByParamComma: groupByParam ','? ;
-
-groupByParam: object DOT attribute (DOT attribute)* ;
+groupByItem: objectPathExpression ;
 
 inputParameter: COLON IDENTIFICATION_VARIABLE ;
 
@@ -159,11 +159,11 @@ AND: 'AND' ;
 
 OR: 'OR' ;
 
-ORDERBY: 'ORDER BY' ;
+BY: 'BY' ;
 
-ORDERING: ASC | DESC ;
+ORDER: 'ORDER' ;
 
-GROUPBY: 'GROUP BY' ;
+GROUP: 'GROUP' ;
 
 ASC: 'ASC' ;
 

--- a/jopa-impl/src/main/antlr4/cz/cvut/kbss/jopa/query/soql/Soql.g4
+++ b/jopa-impl/src/main/antlr4/cz/cvut/kbss/jopa/query/soql/Soql.g4
@@ -20,11 +20,9 @@ selectExpression: simplePath | aggregateExpression ;
 
 aggregateExpression: COUNT '(' (DISTINCT)? simplePath ')';
 
-fromClause: FROM entityName identificationVariable;
+fromClause: FROM entityName IDENTIFICATION_VARIABLE;
 
 entityName: IDENTIFICATION_VARIABLE ;
-
-identificationVariable: IDENTIFICATION_VARIABLE ;
 
 whereClause
     : WHERE conditionalExpression

--- a/jopa-impl/src/main/antlr4/cz/cvut/kbss/jopa/query/soql/Soql.g4
+++ b/jopa-impl/src/main/antlr4/cz/cvut/kbss/jopa/query/soql/Soql.g4
@@ -53,11 +53,15 @@ inExpression
 
 inItem
    : literal
-   | whereClauseValue
+   | inputParameter
    ;
 
 literal
-   :
+   : STRING_LITERAL
+   | INT_LITERAL
+   | FLOAT_LITERAL
+   | BOOLEAN_LITERAL
+   | IDENTIFICATION_VARIABLE
    ;
 
 likeExpression

--- a/jopa-impl/src/main/antlr4/cz/cvut/kbss/jopa/query/soql/Soql.g4
+++ b/jopa-impl/src/main/antlr4/cz/cvut/kbss/jopa/query/soql/Soql.g4
@@ -1,21 +1,16 @@
 grammar Soql;
 
+start: querySentence EOF ;
 
-querySentence : selectStatement whereClauseWrapper? groupByClause? orderByClause? ;
+querySentence: selectStatement ;
 
-selectStatement: typeDef params FROM tables ;
+selectStatement: selectClause fromClause whereClause? groupByClause? orderByClause? ;
 
-typeDef: SELECT ;
+selectClause: SELECT (DISTINCT)? selectItem (',' selectItem)* ;
 
-params: paramComma* distinctParam ;
+selectItem: selectExpression;
 
-paramComma: distinctParam ',' ;
-
-distinctParam: distinct? selectedParam ;
-
-selectedParam: param | count;
-
-count: COUNT '(' param ')' ;
+selectExpression: param | count ;
 
 param: objWithAttr | objWithOutAttr ;
 
@@ -23,26 +18,21 @@ objWithAttr: object DOT attribute;
 
 objWithOutAttr: object ;
 
-distinct: DISTINCT ;
-
 object: IDENTIFICATION_VARIABLE ;
+
+count: COUNT '(' param ')' ;
 
 attribute: IDENTIFICATION_VARIABLE ;
 
 joinedParams: object DOT attribute (DOT attribute)+ ;
 
+fromClause: FROM entityName identificationVariable;
 
+entityName: IDENTIFICATION_VARIABLE ;
 
-tables: tableWithName ;
+identificationVariable: IDENTIFICATION_VARIABLE ;
 
-table: IDENTIFICATION_VARIABLE ;
-
-tableName: IDENTIFICATION_VARIABLE ;
-
-tableWithName: table tableName ;
-
-
-whereClauseWrapper
+whereClause
     : WHERE conditionalExpression
     ;
 

--- a/jopa-impl/src/main/antlr4/cz/cvut/kbss/jopa/query/soql/Soql.g4
+++ b/jopa-impl/src/main/antlr4/cz/cvut/kbss/jopa/query/soql/Soql.g4
@@ -6,19 +6,19 @@ querySentence: selectStatement ;
 
 selectStatement: selectClause fromClause whereClause? groupByClause? orderByClause? ;
 
-objectPathExpression: simplePath DOT objectField ;
+singleValuedObjectPathExpression: simpleSubpath DOT singleValuedObjectField ;
 
-simplePath: objectField (DOT simplePath)* ;
+simpleSubpath: singleValuedObjectField (DOT simpleSubpath)* ;
 
-objectField: IDENTIFICATION_VARIABLE ;
+singleValuedObjectField: IDENTIFICATION_VARIABLE ;
 
 selectClause: SELECT (DISTINCT)? selectItem (',' selectItem)* ;
 
 selectItem: selectExpression;
 
-selectExpression: simplePath | aggregateExpression ;
+selectExpression: simpleSubpath | aggregateExpression ;
 
-aggregateExpression: COUNT '(' (DISTINCT)? simplePath ')';
+aggregateExpression: COUNT '(' (DISTINCT)? simpleSubpath ')';
 
 fromClause: FROM entityName IDENTIFICATION_VARIABLE;
 
@@ -48,7 +48,7 @@ simpleConditionalExpression
    ;
 
 inExpression
-   : simplePath (NOT)? IN '('? (inItem (',' inItem)*) ')'?
+   : simpleSubpath (NOT)? IN '('? (inItem (',' inItem)*) ')'?
    ;
 
 inItem
@@ -69,7 +69,7 @@ likeExpression
    ;
 
 memberOfExpression
-    : inItem (NOT)? MEMBER OF simplePath
+    : inItem (NOT)? MEMBER OF simpleSubpath
     ;
 
 entityExpression
@@ -84,7 +84,7 @@ comparisonExpression
    ;
 
 stringExpression
-   : simplePath
+   : simpleSubpath
    | STRING_LITERAL
    | inputParameter
    | functionsReturningStrings
@@ -95,7 +95,7 @@ functionsReturningStrings
    | 'SUBSTRING' '(' stringExpression ',' simpleArithmeticExpression ',' simpleArithmeticExpression ')'
    | 'LOWER' '(' stringExpression ')'
    | 'UPPER' '(' stringExpression ')'
-   | 'LANG' '(' simplePath ')'
+   | 'LANG' '(' simpleSubpath ')'
    ;
 
 simpleArithmeticExpression
@@ -111,7 +111,7 @@ arithmeticFactor
    ;
 
 arithmeticPrimary
-   : simplePath
+   : simpleSubpath
    | literal
    | '(' simpleArithmeticExpression ')'
    | inputParameter
@@ -128,11 +128,11 @@ functionsReturningNumerics
 
 orderByClause: ORDER BY orderByItem (',' orderByItem)* ;
 
-orderByItem: objectPathExpression (ASC | DESC) ;
+orderByItem: singleValuedObjectPathExpression (ASC | DESC) ;
 
 groupByClause: GROUP BY groupByItem (',' groupByItem)* ;
 
-groupByItem: objectPathExpression ;
+groupByItem: singleValuedObjectPathExpression ;
 
 inputParameter: COLON IDENTIFICATION_VARIABLE ;
 

--- a/jopa-impl/src/main/java/cz/cvut/kbss/jopa/query/soql/SoqlQueryListener.java
+++ b/jopa-impl/src/main/java/cz/cvut/kbss/jopa/query/soql/SoqlQueryListener.java
@@ -452,7 +452,7 @@ public class SoqlQueryListener implements SoqlListener {
     @Override
     public void enterFromClause(SoqlParser.FromClauseContext ctx) {
         String entityName = ctx.entityName().getText();
-        String identificationVariable = ctx.identificationVariable().getText();
+        String identificationVariable = ctx.IDENTIFICATION_VARIABLE().getText();
                 objectTypes.put(identificationVariable, entityName);
         SoqlNode node = new AttributeNode(entityName);
         setObjectIri(node);
@@ -472,16 +472,6 @@ public class SoqlQueryListener implements SoqlListener {
 
     @Override
     public void exitEntityName(SoqlParser.EntityNameContext ctx) {
-
-    }
-
-    @Override
-    public void enterIdentificationVariable(SoqlParser.IdentificationVariableContext ctx) {
-
-    }
-
-    @Override
-    public void exitIdentificationVariable(SoqlParser.IdentificationVariableContext ctx) {
 
     }
 

--- a/jopa-impl/src/main/java/cz/cvut/kbss/jopa/query/soql/SoqlQueryListener.java
+++ b/jopa-impl/src/main/java/cz/cvut/kbss/jopa/query/soql/SoqlQueryListener.java
@@ -402,6 +402,16 @@ public class SoqlQueryListener implements SoqlListener {
     }
 
     @Override
+    public void enterEntityExpression(SoqlParser.EntityExpressionContext ctx) {
+
+    }
+
+    @Override
+    public void exitEntityExpression(SoqlParser.EntityExpressionContext ctx) {
+
+    }
+
+    @Override
     public void enterComparisonExpression(SoqlParser.ComparisonExpressionContext ctx) {
     }
 

--- a/jopa-impl/src/main/java/cz/cvut/kbss/jopa/query/soql/SoqlQueryListener.java
+++ b/jopa-impl/src/main/java/cz/cvut/kbss/jopa/query/soql/SoqlQueryListener.java
@@ -120,18 +120,18 @@ public class SoqlQueryListener implements SoqlListener {
     }
 
     @Override
-    public void enterObjectPathExpression(SoqlParser.ObjectPathExpressionContext ctx) {
+    public void enterSingleValuedObjectPathExpression(SoqlParser.SingleValuedObjectPathExpressionContext ctx) {
 
     }
 
     @Override
-    public void exitObjectPathExpression(SoqlParser.ObjectPathExpressionContext ctx) {
+    public void exitSingleValuedObjectPathExpression(SoqlParser.SingleValuedObjectPathExpressionContext ctx) {
 
     }
 
     @Override
-    public void enterSimplePath(SoqlParser.SimplePathContext ctx) {
-        if(ctx.simplePath() == null) {
+    public void enterSimpleSubpath(SoqlParser.SimpleSubpathContext ctx) {
+        if(ctx.simpleSubpath() == null) {
             return;
         }
 
@@ -140,11 +140,11 @@ public class SoqlQueryListener implements SoqlListener {
         }
 
         // node was already processed by parent
-        if(ctx.getParent() instanceof SoqlParser.SimplePathContext) {
+        if(ctx.getParent() instanceof SoqlParser.SimpleSubpathContext) {
             return;
         }
 
-        SoqlNode owner = linkSimplePath(ctx);
+        SoqlNode owner = linkSimpleSubpath(ctx);
 
         // don't add top level references multiple times
         if(!owner.hasChild() && objectTypes.containsKey(owner.getValue())) {
@@ -165,7 +165,7 @@ public class SoqlQueryListener implements SoqlListener {
         }
     }
 
-    private SoqlNode linkSimplePath(ParserRuleContext ctx) {
+    private SoqlNode linkSimpleSubpath(ParserRuleContext ctx) {
         AttributeNode firstNode = new AttributeNode(getOwnerFromParam(ctx));
         AttributeNode currentNode = firstNode;
 
@@ -186,17 +186,18 @@ public class SoqlQueryListener implements SoqlListener {
     }
 
     @Override
-    public void exitSimplePath(SoqlParser.SimplePathContext ctx) {
+    public void exitSimpleSubpath(SoqlParser.SimpleSubpathContext ctx) {
 
     }
 
     @Override
-    public void enterObjectField(SoqlParser.ObjectFieldContext ctx) {
+    public void enterSingleValuedObjectField(SoqlParser.SingleValuedObjectFieldContext ctx) {
 
     }
 
     @Override
-    public void exitObjectField(SoqlParser.ObjectFieldContext ctx) {
+    public void exitSingleValuedObjectField(SoqlParser.SingleValuedObjectFieldContext ctx) {
+
     }
 
     @Override
@@ -252,8 +253,8 @@ public class SoqlQueryListener implements SoqlListener {
                 isSelectedParamDistinct = true;
             }
 
-            if(ctx.simplePath() != null) {
-                this.projectedVariable = ctx.simplePath().getText();
+            if(ctx.simpleSubpath() != null) {
+                this.projectedVariable = ctx.simpleSubpath().getText();
             }
         }
     }

--- a/jopa-impl/src/main/java/cz/cvut/kbss/jopa/query/soql/SoqlQueryListener.java
+++ b/jopa-impl/src/main/java/cz/cvut/kbss/jopa/query/soql/SoqlQueryListener.java
@@ -486,14 +486,6 @@ public class SoqlQueryListener implements SoqlListener {
     }
 
     @Override
-    public void enterWhereClauseValue(SoqlParser.WhereClauseValueContext ctx) {
-    }
-
-    @Override
-    public void exitWhereClauseValue(SoqlParser.WhereClauseValueContext ctx) {
-    }
-
-    @Override
     public void enterStringExpression(SoqlParser.StringExpressionContext ctx) {
 
     }

--- a/jopa-impl/src/main/java/cz/cvut/kbss/jopa/query/soql/SoqlQueryListener.java
+++ b/jopa-impl/src/main/java/cz/cvut/kbss/jopa/query/soql/SoqlQueryListener.java
@@ -90,6 +90,16 @@ public class SoqlQueryListener implements SoqlListener {
     }
 
     @Override
+    public void enterStart(SoqlParser.StartContext ctx) {
+
+    }
+
+    @Override
+    public void exitStart(SoqlParser.StartContext ctx) {
+
+    }
+
+    @Override
     public void enterQuerySentence(SoqlParser.QuerySentenceContext ctx) {
     }
 
@@ -101,18 +111,41 @@ public class SoqlQueryListener implements SoqlListener {
 
     @Override
     public void enterSelectStatement(SoqlParser.SelectStatementContext ctx) {
+
     }
 
     @Override
     public void exitSelectStatement(SoqlParser.SelectStatementContext ctx) {
+
     }
 
     @Override
-    public void enterParams(SoqlParser.ParamsContext ctx) {
+    public void enterSelectClause(SoqlParser.SelectClauseContext ctx) {
+        this.typeDef = SparqlConstants.SELECT;
+
+        if(ctx.DISTINCT() != null) {
+            this.isSelectedParamDistinct = true;
+        }
     }
 
     @Override
-    public void exitParams(SoqlParser.ParamsContext ctx) {
+    public void exitSelectClause(SoqlParser.SelectClauseContext ctx) {
+
+    }
+
+    @Override
+    public void enterSelectItem(SoqlParser.SelectItemContext ctx) {
+
+    }
+
+    @Override
+    public void exitSelectItem(SoqlParser.SelectItemContext ctx) {
+
+    }
+
+    @Override
+    public void enterSelectExpression(SoqlParser.SelectExpressionContext ctx) {
+
     }
 
     @Override
@@ -144,27 +177,7 @@ public class SoqlQueryListener implements SoqlListener {
     }
 
     @Override
-    public void enterParamComma(SoqlParser.ParamCommaContext ctx) {
-    }
-
-    @Override
-    public void exitParamComma(SoqlParser.ParamCommaContext ctx) {
-    }
-
-    @Override
-    public void enterDistinctParam(SoqlParser.DistinctParamContext ctx) {
-    }
-
-    @Override
-    public void exitDistinctParam(SoqlParser.DistinctParamContext ctx) {
-    }
-
-    @Override
-    public void enterSelectedParam(SoqlParser.SelectedParamContext ctx) {
-    }
-
-    @Override
-    public void exitSelectedParam(SoqlParser.SelectedParamContext ctx) {
+    public void exitSelectExpression(SoqlParser.SelectExpressionContext ctx) {
         if (!isSelectedParamCount) {
             this.projectedVariable = ctx.getText();
         }
@@ -245,34 +258,6 @@ public class SoqlQueryListener implements SoqlListener {
 
     @Override
     public void exitAttribute(SoqlParser.AttributeContext ctx) {
-    }
-
-    @Override
-    public void enterTypeDef(SoqlParser.TypeDefContext ctx) {
-        typeDef = ctx.getChild(0).getText();
-    }
-
-    @Override
-    public void exitTypeDef(SoqlParser.TypeDefContext ctx) {
-    }
-
-    @Override
-    public void enterDistinct(SoqlParser.DistinctContext ctx) {
-        if (SoqlConstants.DISTINCT.equals(ctx.getChild(0).getText())) {
-            isSelectedParamDistinct = true;
-        }
-    }
-
-    @Override
-    public void exitDistinct(SoqlParser.DistinctContext ctx) {
-    }
-
-    @Override
-    public void enterWhereClauseWrapper(SoqlParser.WhereClauseWrapperContext ctx) {
-    }
-
-    @Override
-    public void exitWhereClauseWrapper(SoqlParser.WhereClauseWrapperContext ctx) {
     }
 
     @Override
@@ -437,42 +422,49 @@ public class SoqlQueryListener implements SoqlListener {
     }
 
     @Override
-    public void enterTables(SoqlParser.TablesContext ctx) {
-    }
-
-    @Override
-    public void exitTables(SoqlParser.TablesContext ctx) {
-    }
-
-    @Override
-    public void enterTable(SoqlParser.TableContext ctx) {
-    }
-
-    @Override
-    public void exitTable(SoqlParser.TableContext ctx) {
-    }
-
-    @Override
-    public void enterTableName(SoqlParser.TableNameContext ctx) {
-    }
-
-    @Override
-    public void exitTableName(SoqlParser.TableNameContext ctx) {
-    }
-
-    @Override
-    public void enterTableWithName(SoqlParser.TableWithNameContext ctx) {
-        String table = ctx.getChild(0).getChild(0).getText();
-        String objectName = ctx.getChild(1).getChild(0).getText();
-        objectTypes.put(objectName, table);
-        SoqlNode node = new AttributeNode(table);
+    public void enterFromClause(SoqlParser.FromClauseContext ctx) {
+        String entityName = ctx.entityName().getText();
+        String identificationVariable = ctx.identificationVariable().getText();
+                objectTypes.put(identificationVariable, entityName);
+        SoqlNode node = new AttributeNode(entityName);
         setObjectIri(node);
         SoqlAttribute myAttr = new SoqlAttribute(node);
         pushNewAttribute(myAttr);
     }
 
     @Override
-    public void exitTableWithName(SoqlParser.TableWithNameContext ctx) {
+    public void exitFromClause(SoqlParser.FromClauseContext ctx) {
+
+    }
+
+    @Override
+    public void enterEntityName(SoqlParser.EntityNameContext ctx) {
+
+    }
+
+    @Override
+    public void exitEntityName(SoqlParser.EntityNameContext ctx) {
+
+    }
+
+    @Override
+    public void enterIdentificationVariable(SoqlParser.IdentificationVariableContext ctx) {
+
+    }
+
+    @Override
+    public void exitIdentificationVariable(SoqlParser.IdentificationVariableContext ctx) {
+
+    }
+
+    @Override
+    public void enterWhereClause(SoqlParser.WhereClauseContext ctx) {
+
+    }
+
+    @Override
+    public void exitWhereClause(SoqlParser.WhereClauseContext ctx) {
+
     }
 
     @Override

--- a/jopa-impl/src/main/java/cz/cvut/kbss/jopa/query/soql/SoqlQueryListener.java
+++ b/jopa-impl/src/main/java/cz/cvut/kbss/jopa/query/soql/SoqlQueryListener.java
@@ -131,7 +131,58 @@ public class SoqlQueryListener implements SoqlListener {
 
     @Override
     public void enterSimplePath(SoqlParser.SimplePathContext ctx) {
+        if(ctx.simplePath() == null) {
+            return;
+        }
 
+        if(ctx.getChildCount() == 1) {
+            return;
+        }
+
+        // node was already processed by parent
+        if(ctx.getParent() instanceof SoqlParser.SimplePathContext) {
+            return;
+        }
+
+        SoqlNode owner = linkSimplePath(ctx);
+
+        // don't add top level references multiple times
+        if(!owner.hasChild() && objectTypes.containsKey(owner.getValue())) {
+            return;
+        }
+
+        SoqlAttribute newAttr = new SoqlAttribute(owner);
+        if (owner.hasChild() && isIdentifier(owner, owner.getChild())) {
+            this.isInObjectIdentifierExpression = true;
+            if (projectedVariable.equals(owner.getValue()) && currentPointerIsNotAttributeReference()) {
+                attrPointer.setProjected(true);
+            } else {
+                newAttr.setProjected(true);
+                pushNewAttribute(newAttr);
+            }
+        } else {
+            pushNewAttribute(newAttr);
+        }
+    }
+
+    private SoqlNode linkSimplePath(ParserRuleContext ctx) {
+        AttributeNode firstNode = new AttributeNode(getOwnerFromParam(ctx));
+        AttributeNode currentNode = firstNode;
+
+        while (ctx.getChildCount() == 3) {
+            ctx = (ParserRuleContext) ctx.getChild(2);
+            SoqlNode prevNode = currentNode;
+            currentNode = new AttributeNode(prevNode, ctx.getChild(0).getText());
+            prevNode.setChild(currentNode);
+        }
+        setIris(firstNode);
+        if (currentNode.getIri().isEmpty()) {
+            this.isInObjectIdentifierExpression = true;
+            if (projectedVariable != null && projectedVariable.equals(firstNode.getValue()) && currentPointerIsNotAttributeReference()) {
+                attrPointer.setProjected(true);
+            }
+        }
+        return firstNode;
     }
 
     @Override
@@ -146,7 +197,6 @@ public class SoqlQueryListener implements SoqlListener {
 
     @Override
     public void exitObjectField(SoqlParser.ObjectFieldContext ctx) {
-
     }
 
     @Override
@@ -178,21 +228,6 @@ public class SoqlQueryListener implements SoqlListener {
 
     }
 
-    @Override
-    public void enterParam(SoqlParser.ParamContext ctx) {
-    }
-
-    @Override
-    public void exitParam(SoqlParser.ParamContext ctx) {
-    }
-
-    @Override
-    public void enterJoinedParams(SoqlParser.JoinedParamsContext ctx) {
-        SoqlNode firstNode = linkContextNodes(ctx);
-        SoqlAttribute myAttr = new SoqlAttribute(firstNode);
-        pushNewAttribute(myAttr);
-    }
-
     private void pushNewAttribute(SoqlAttribute myAttr) {
         attributes.add(myAttr);
         this.attrPointer = myAttr;
@@ -203,10 +238,6 @@ public class SoqlQueryListener implements SoqlListener {
     }
 
     @Override
-    public void exitJoinedParams(SoqlParser.JoinedParamsContext ctx) {
-    }
-
-    @Override
     public void exitSelectExpression(SoqlParser.SelectExpressionContext ctx) {
         if (!isSelectedParamCount) {
             this.projectedVariable = ctx.getText();
@@ -214,44 +245,22 @@ public class SoqlQueryListener implements SoqlListener {
     }
 
     @Override
-    public void enterCount(SoqlParser.CountContext ctx) {
-        isSelectedParamCount = true;
-    }
-
-    @Override
-    public void exitCount(SoqlParser.CountContext ctx) {
-        this.projectedVariable = ctx.getChild(2).getText();
-    }
-
-    @Override
-    public void enterObject(SoqlParser.ObjectContext ctx) {
-    }
-
-    @Override
-    public void exitObject(SoqlParser.ObjectContext ctx) {
-    }
-
-    @Override
-    public void enterObjWithAttr(SoqlParser.ObjWithAttrContext ctx) {
-        String owner = getOwnerFromParam(ctx);
-        String attribute = getAttributeFromParam(ctx);
-        // objectNode.attributeNode
-        SoqlNode objectNode = new AttributeNode(owner);
-        SoqlNode attributeNode = new AttributeNode(objectNode, attribute);
-        objectNode.setChild(attributeNode);
-        setIris(objectNode);
-        SoqlAttribute newAttr = new SoqlAttribute(objectNode);
-        if (isIdentifier(objectNode, attributeNode)) {
-            this.isInObjectIdentifierExpression = true;
-            if (projectedVariable.equals(objectNode.getValue()) && currentPointerIsNotAttributeReference()) {
-                attrPointer.setProjected(true);
-            } else {
-                newAttr.setProjected(true);
-                pushNewAttribute(newAttr);
+    public void enterAggregateExpression(SoqlParser.AggregateExpressionContext ctx) {
+        if(ctx.COUNT() != null) {
+            isSelectedParamCount = true;
+            if(ctx.DISTINCT() != null) {
+                isSelectedParamDistinct = true;
             }
-        } else {
-            pushNewAttribute(newAttr);
+
+            if(ctx.simplePath() != null) {
+                this.projectedVariable = ctx.simplePath().getText();
+            }
         }
+    }
+
+    @Override
+    public void exitAggregateExpression(SoqlParser.AggregateExpressionContext ctx) {
+
     }
 
     private boolean isIdentifier(SoqlNode objectNode, SoqlNode attributeNode) {
@@ -268,26 +277,6 @@ public class SoqlQueryListener implements SoqlListener {
 
     private boolean currentPointerIsNotAttributeReference() {
         return !attrPointer.getFirstNode().hasChild();
-    }
-
-    @Override
-    public void exitObjWithAttr(SoqlParser.ObjWithAttrContext ctx) {
-    }
-
-    @Override
-    public void enterObjWithOutAttr(SoqlParser.ObjWithOutAttrContext ctx) {
-    }
-
-    @Override
-    public void exitObjWithOutAttr(SoqlParser.ObjWithOutAttrContext ctx) {
-    }
-
-    @Override
-    public void enterAttribute(SoqlParser.AttributeContext ctx) {
-    }
-
-    @Override
-    public void exitAttribute(SoqlParser.AttributeContext ctx) {
     }
 
     @Override
@@ -340,7 +329,7 @@ public class SoqlQueryListener implements SoqlListener {
             pushNewAttribute(createSyntheticAttributeForEntityId());
         }
         final ParseTree value = resolveInExpressionValue(ctx);
-        if (ctx.getChild(1).getText().equals(SoqlConstants.NOT)) {
+        if (ctx.NOT() != null) {
             attrPointer.setOperator(InOperator.notIn());
         } else {
             attrPointer.setOperator(InOperator.in());
@@ -350,17 +339,16 @@ public class SoqlQueryListener implements SoqlListener {
     }
 
     private SoqlAttribute createSyntheticAttributeForEntityId() {
-        return new SoqlAttribute(
-                attrPointer.getFirstNode().hasChild() ? attrPointer.getFirstNode().getChild() :
-                        new AttributeNode(rootVariable.substring(1)));
+        if(attrPointer.getFirstNode().hasChild()) {
+            attrPointer.getFirstNode().getChild().setChild(null);
+            return new SoqlAttribute(attrPointer.getFirstNode().getChild());
+        }
+
+        return new SoqlAttribute(new AttributeNode(rootVariable.substring(1)));
     }
 
     private ParseTree resolveInExpressionValue(SoqlParser.InExpressionContext ctx) {
-        final ParseTree lastToken = ctx.getChild(ctx.getChildCount() - 1);
-        if (")".equals(lastToken.getText())) {
-            return ctx.getChild(ctx.getChildCount() - 2);
-        }
-        return lastToken;
+        return ctx.inItem().get(ctx.inItem().size() - 1);
     }
 
     @Override
@@ -503,14 +491,6 @@ public class SoqlQueryListener implements SoqlListener {
 
     @Override
     public void exitWhereClauseValue(SoqlParser.WhereClauseValueContext ctx) {
-    }
-
-    @Override
-    public void enterWhereClauseParam(SoqlParser.WhereClauseParamContext ctx) {
-    }
-
-    @Override
-    public void exitWhereClauseParam(SoqlParser.WhereClauseParamContext ctx) {
     }
 
     @Override

--- a/jopa-impl/src/main/java/cz/cvut/kbss/jopa/query/soql/SoqlQueryListener.java
+++ b/jopa-impl/src/main/java/cz/cvut/kbss/jopa/query/soql/SoqlQueryListener.java
@@ -678,6 +678,16 @@ public class SoqlQueryListener implements SoqlListener {
     }
 
     @Override
+    public void enterComparisonOperator(SoqlParser.ComparisonOperatorContext ctx) {
+
+    }
+
+    @Override
+    public void exitComparisonOperator(SoqlParser.ComparisonOperatorContext ctx) {
+
+    }
+
+    @Override
     public void visitTerminal(TerminalNode terminalNode) {
     }
 

--- a/jopa-impl/src/main/java/cz/cvut/kbss/jopa/query/soql/SoqlQueryListener.java
+++ b/jopa-impl/src/main/java/cz/cvut/kbss/jopa/query/soql/SoqlQueryListener.java
@@ -120,6 +120,36 @@ public class SoqlQueryListener implements SoqlListener {
     }
 
     @Override
+    public void enterObjectPathExpression(SoqlParser.ObjectPathExpressionContext ctx) {
+
+    }
+
+    @Override
+    public void exitObjectPathExpression(SoqlParser.ObjectPathExpressionContext ctx) {
+
+    }
+
+    @Override
+    public void enterSimplePath(SoqlParser.SimplePathContext ctx) {
+
+    }
+
+    @Override
+    public void exitSimplePath(SoqlParser.SimplePathContext ctx) {
+
+    }
+
+    @Override
+    public void enterObjectField(SoqlParser.ObjectFieldContext ctx) {
+
+    }
+
+    @Override
+    public void exitObjectField(SoqlParser.ObjectFieldContext ctx) {
+
+    }
+
+    @Override
     public void enterSelectClause(SoqlParser.SelectClauseContext ctx) {
         this.typeDef = SparqlConstants.SELECT;
 
@@ -565,24 +595,8 @@ public class SoqlQueryListener implements SoqlListener {
     }
 
     @Override
-    public void enterOrderByFullFormComma(SoqlParser.OrderByFullFormCommaContext ctx) {
-    }
-
-    @Override
-    public void exitOrderByFullFormComma(SoqlParser.OrderByFullFormCommaContext ctx) {
-    }
-
-    @Override
-    public void enterOrderByFullForm(SoqlParser.OrderByFullFormContext ctx) {
-    }
-
-    @Override
-    public void exitOrderByFullForm(SoqlParser.OrderByFullFormContext ctx) {
-    }
-
-    @Override
-    public void enterOrderByParam(SoqlParser.OrderByParamContext ctx) {
-        SoqlNode firstNode = linkContextNodes(ctx);
+    public void enterOrderByItem(SoqlParser.OrderByItemContext ctx) {
+        SoqlNode firstNode = linkObjectPathExpression(ctx);
         String orderingBy = getOrderingBy(ctx.getParent());
         SoqlOrderParameter orderParam = new SoqlOrderParameter(firstNode, orderingBy);
         boolean attrSet = false;
@@ -603,11 +617,12 @@ public class SoqlQueryListener implements SoqlListener {
     }
 
     @Override
-    public void exitOrderByParam(SoqlParser.OrderByParamContext ctx) {
+    public void exitOrderByItem(SoqlParser.OrderByItemContext ctx) {
     }
 
     @Override
     public void enterGroupByClause(SoqlParser.GroupByClauseContext ctx) {
+
     }
 
     @Override
@@ -615,16 +630,8 @@ public class SoqlQueryListener implements SoqlListener {
     }
 
     @Override
-    public void enterGroupByParamComma(SoqlParser.GroupByParamCommaContext ctx) {
-    }
-
-    @Override
-    public void exitGroupByParamComma(SoqlParser.GroupByParamCommaContext ctx) {
-    }
-
-    @Override
-    public void enterGroupByParam(SoqlParser.GroupByParamContext ctx) {
-        SoqlNode firstNode = linkContextNodes(ctx);
+    public void enterGroupByItem(SoqlParser.GroupByItemContext ctx) {
+        SoqlNode firstNode = linkObjectPathExpression(ctx);
         SoqlGroupParameter groupParam = new SoqlGroupParameter(firstNode);
         boolean attrSet = false;
         for (SoqlAttribute attr : attributes) {
@@ -643,6 +650,11 @@ public class SoqlQueryListener implements SoqlListener {
         groupAttributes.add(groupParam);
     }
 
+    @Override
+    public void exitGroupByItem(SoqlParser.GroupByItemContext ctx) {
+
+    }
+
     private SoqlNode linkContextNodes(ParserRuleContext ctx) {
         SoqlNode firstNode = new AttributeNode(getOwnerFromParam(ctx));
         SoqlNode currentNode = firstNode;
@@ -659,8 +671,20 @@ public class SoqlQueryListener implements SoqlListener {
         return firstNode;
     }
 
-    @Override
-    public void exitGroupByParam(SoqlParser.GroupByParamContext ctx) {
+    private SoqlNode linkObjectPathExpression(ParserRuleContext ctx) {
+        SoqlNode firstNode = new AttributeNode(getOwnerFromParam(ctx));
+        SoqlNode currentNode = firstNode;
+        for (int i = 2; i < ctx.getChild(0).getChildCount(); i += 2) {
+            SoqlNode prevNode = currentNode;
+            currentNode = new AttributeNode(prevNode, ctx.getChild(0).getChild(i).getText());
+            prevNode.setChild(currentNode);
+        }
+        setIris(firstNode);
+        if (currentNode.getIri().isEmpty()) {
+            currentNode.getParent().setChild(null);
+            this.isInObjectIdentifierExpression = true;
+        }
+        return firstNode;
     }
 
     @Override


### PR DESCRIPTION
This PR aims to simplify the `SOQL` grammar and implementation of the `SoqlQueryListener`.
The goal is to align the feature set of `SOQL` more closely with the SQL equivalents like `JPQL` implemented in [spring-data-jpa](https://github.com/spring-projects/spring-data-jpa)