### PR TITLE
Feature/306 em trigger lazy loading

### DIFF
--- a/jopa-integration-tests-owlapi/src/test/java/cz/cvut/kbss/jopa/test/integration/owlapi/DeleteOperationsTest.java
+++ b/jopa-integration-tests-owlapi/src/test/java/cz/cvut/kbss/jopa/test/integration/owlapi/DeleteOperationsTest.java
@@ -17,6 +17,10 @@
  */
 package cz.cvut.kbss.jopa.test.integration.owlapi;
 
+import cz.cvut.kbss.jopa.proxy.lazy.LazyLoadingProxy;
+import cz.cvut.kbss.jopa.test.OWLClassA;
+import cz.cvut.kbss.jopa.test.OWLClassI;
+import cz.cvut.kbss.jopa.test.Vocabulary;
 import cz.cvut.kbss.jopa.test.environment.OwlapiDataAccessor;
 import cz.cvut.kbss.jopa.test.environment.OwlapiPersistenceFactory;
 import cz.cvut.kbss.jopa.test.runner.DeleteOperationsRunner;
@@ -24,6 +28,10 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class DeleteOperationsTest extends DeleteOperationsRunner {
 
@@ -45,5 +53,28 @@ public class DeleteOperationsTest extends DeleteOperationsRunner {
     @Override
     public void clearingDatatypeCollectionRemovesAllValues() {
         // Another issue with OWL2Query, causes reasoner exception
+    }
+
+    @Test
+    @Override
+    public void removeTriggersLazyLoading() {
+        // OWL doesn't remove all statements, unlike RDF4J and Jena, but keeps certain top-level attributes. That's why this test has to be overriden
+        this.em = getEntityManager("removeTriggersLazyLoading", true);
+        persist(entityI);
+
+        em.getEntityManagerFactory().getCache().evictAll();
+        final OWLClassI resI = findRequired(OWLClassI.class, entityI.getUri());
+        assertInstanceOf(LazyLoadingProxy.class, resI.getOwlClassA());
+
+        em.getTransaction().begin();
+        em.remove(resI.getOwlClassA());
+        em.getTransaction().commit();
+
+        assertNull(em.find(OWLClassA.class, entityA.getUri()));
+
+        // verify that the attributes of A were removed
+        assertFalse(
+                em.createNativeQuery("ASK { ?x <"+ Vocabulary.P_A_STRING_ATTRIBUTE + "> ?z .}", Boolean.class).setParameter("x", entityA.getUri())
+                  .getSingleResult());
     }
 }

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/DeleteOperationsRunner.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/DeleteOperationsRunner.java
@@ -503,7 +503,7 @@ public abstract class DeleteOperationsRunner extends BaseRunner {
     }
 
     @Test
-    void removeTriggersLazyLoading() {
+    public void removeTriggersLazyLoading() {
         this.em = getEntityManager("removeTriggersLazyLoading", true);
         persist(entityI);
 

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/DeleteOperationsRunner.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/DeleteOperationsRunner.java
@@ -21,6 +21,7 @@ import cz.cvut.kbss.jopa.model.annotations.Id;
 import cz.cvut.kbss.jopa.model.annotations.OWLAnnotationProperty;
 import cz.cvut.kbss.jopa.model.annotations.OWLDataProperty;
 import cz.cvut.kbss.jopa.model.annotations.OWLObjectProperty;
+import cz.cvut.kbss.jopa.proxy.lazy.LazyLoadingProxy;
 import cz.cvut.kbss.jopa.test.*;
 import cz.cvut.kbss.jopa.test.environment.DataAccessor;
 import cz.cvut.kbss.jopa.test.environment.Generators;
@@ -498,6 +499,25 @@ public abstract class DeleteOperationsRunner extends BaseRunner {
 
         assertFalse(
                 em.createNativeQuery("ASK { ?x ?y ?z .}", Boolean.class).setParameter("x", URI.create(entityM.getKey()))
+                  .getSingleResult());
+    }
+
+    @Test
+    void removeTriggersLazyLoading() {
+        this.em = getEntityManager("removeTriggersLazyLoading", true);
+        persist(entityI);
+
+        em.getEntityManagerFactory().getCache().evictAll();
+        final OWLClassI resI = findRequired(OWLClassI.class, entityI.getUri());
+        assertInstanceOf(LazyLoadingProxy.class, resI.getOwlClassA());
+
+        em.getTransaction().begin();
+        em.remove(resI.getOwlClassA());
+        em.getTransaction().commit();
+
+        assertNull(em.find(OWLClassA.class, entityA.getUri()));
+        assertFalse(
+                em.createNativeQuery("ASK { ?x ?y ?z .}", Boolean.class).setParameter("x", entityA.getUri())
                   .getSingleResult());
     }
 }

--- a/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/RetrieveOperationsRunner.java
+++ b/jopa-integration-tests/src/main/java/cz/cvut/kbss/jopa/test/runner/RetrieveOperationsRunner.java
@@ -18,7 +18,6 @@
 package cz.cvut.kbss.jopa.test.runner;
 
 import cz.cvut.kbss.jopa.model.JOPAPersistenceProperties;
-import cz.cvut.kbss.jopa.model.SequencesVocabulary;
 import cz.cvut.kbss.jopa.model.descriptors.Descriptor;
 import cz.cvut.kbss.jopa.model.descriptors.EntityDescriptor;
 import cz.cvut.kbss.jopa.model.query.TypedQuery;
@@ -47,7 +46,6 @@ import cz.cvut.kbss.jopa.test.environment.DataAccessor;
 import cz.cvut.kbss.jopa.test.environment.Generators;
 import cz.cvut.kbss.jopa.test.environment.PersistenceFactory;
 import cz.cvut.kbss.jopa.test.environment.Quad;
-import cz.cvut.kbss.jopa.test.environment.TestEnvironment;
 import cz.cvut.kbss.jopa.vocabulary.RDF;
 import cz.cvut.kbss.jopa.vocabulary.XSD;
 import cz.cvut.kbss.ontodriver.ReloadableDataSource;
@@ -74,7 +72,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -184,6 +181,17 @@ public abstract class RetrieveOperationsRunner extends BaseRunner {
         assertNotNull(resI.getOwlClassA().getUri());
         assertEquals(entityA.getUri(), resI.getOwlClassA().getUri());
         assertTrue(em.contains(resI.getOwlClassA()));
+    }
+
+    @Test
+    void testContainsTriggersLoadingLazyLoadedAttribute() {
+        this.em = getEntityManager("ContainsTriggersLazyLoading", false);
+        persist(entityI);
+
+        final OWLClassI resI = findRequired(OWLClassI.class, entityI.getUri());
+        assertInstanceOf(LazyLoadingProxy.class, resI.getOwlClassA());
+        assertTrue(em.contains(resI.getOwlClassA()));
+        assertInstanceOf(OWLClassA.class, resI.getOwlClassA());
     }
 
     @Test


### PR DESCRIPTION
This PR fixes #306  by triggering lazy loading when `EntityManagerImpl` is presented with a `LazyLoadingProxy` in the `contains` and `remove` methods.