### PR TITLE
Sanitize field name in OWL2Java transformation

### DIFF
--- a/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/JavaNameGenerator.java
+++ b/jopa-owl2java/src/main/java/cz/cvut/kbss/jopa/owl2java/JavaNameGenerator.java
@@ -21,6 +21,7 @@ import cz.cvut.kbss.jopa.owl2java.prefix.PrefixMap;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLOntologyID;
 
+import javax.lang.model.SourceVersion;
 import java.text.Normalizer;
 import java.util.Arrays;
 import java.util.Objects;
@@ -123,7 +124,33 @@ public class JavaNameGenerator {
         if (Arrays.binarySearch(JAVA_KEYWORDS, res) >= 0) {
             res = SEPARATOR + res;
         }
-        return res;
+        return sanitizeJavaIdentifier(res);
+    }
+
+    /**
+     * Filters the specified name so that it contains only characters allowed for Java identifiers.
+     * If the first character (before filtering) must not be at the start,
+     * an underscore ("_") is prepended.
+     * If the resulting field name (after filtering) matches any Java keyword,
+     * an underscore ("_") is appended.
+     * @param name the name to filter
+     * @return a valid Java identifier
+     * @see <a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-3.html#jls-3.8">Java 17 Spec</a>
+     */
+    private static String sanitizeJavaIdentifier(String name) {
+        StringBuilder sb = new StringBuilder();
+        if (!Character.isJavaIdentifierStart(name.charAt(0))) {
+            sb.append("_");
+        }
+        for (int i = 0; i < name.length(); i++) {
+            if (Character.isJavaIdentifierPart(name.charAt(i))) {
+                sb.append(name.charAt(i));
+            }
+        }
+        if (SourceVersion.isKeyword(sb)) {
+            sb.append("_");
+        }
+        return sb.toString();
     }
 
     /**


### PR DESCRIPTION
In certain cases, OWL2Java can generate a Vocabulary class with invalid field names, causing compilation errors.

The issue was discovered when using an ontology importing `https://www.w3.org/ns/dcat3`.
The DCAT ontology contains the following statements (showing only relevant):
```
<http://www.w3.org/ns/dcat>
  a owl:Ontology ;
  bibo:translator [
      a foaf:Person ;
      foaf:homepage <http://www.asahi-net.or.jp/~ax2s-kmtn/> ;
      foaf:name "Shuji Kamitsuna" ;
    ] ;
```
The Vocabulary class will generate with the following fields, causing a compilation error:

```Java
public final static String s_i_dcat_~ax2s_kmtn = "http://www.asahi-net.or.jp/~ax2s-kmtn/";
public final static URI u_i_dcat_~ax2s_kmtn = URI.create(s_i_dcat_~ax2s_kmtn);
```

This PR adds a sanitization method that removes invalid characters from the field names.