### PR TITLE
OWLAbstractClass to indicate abstract super class

### DIFF
--- a/jopa-api/src/main/java/cz/cvut/kbss/jopa/model/annotations/OWLAbstractClass.java
+++ b/jopa-api/src/main/java/cz/cvut/kbss/jopa/model/annotations/OWLAbstractClass.java
@@ -1,0 +1,37 @@
+/*
+ * JOPA
+ * Copyright (C) 2025 Czech Technical University in Prague
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package cz.cvut.kbss.jopa.model.annotations;
+
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies that the class is an abstract class.
+ * <p>
+ * This annotation is applied to the abstract class.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface OWLAbstractClass {
+
+}


### PR DESCRIPTION
Added OWLAbstractClass that can be used next to OWLClass. 

Needed for:  https://github.com/kbss-cvut/jb4jsonld/pull/87 and https://github.com/kbss-cvut/jb4jsonld-jackson/pull/27