### PR TITLE
[Bug #413] Permit variables in graphOrDefault clauses (add, move copy)

### DIFF
--- a/jopa-impl/src/main/antlr4/cz/cvut/kbss/jopa/query/sparql/SparqlParser.g4
+++ b/jopa-impl/src/main/antlr4/cz/cvut/kbss/jopa/query/sparql/SparqlParser.g4
@@ -183,15 +183,15 @@ create
     ;
 
 add
-    : ADD SILENT? graphOrDefault TO graphOrDefault
+    : ADD SILENT? graphOrVarOrDefault TO graphOrVarOrDefault
     ;
 
 move
-    : MOVE SILENT? graphOrDefault TO graphOrDefault
+    : MOVE SILENT? graphOrVarOrDefault TO graphOrVarOrDefault
     ;
 
 copy
-    : COPY SILENT? graphOrDefault TO graphOrDefault
+    : COPY SILENT? graphOrVarOrDefault TO graphOrVarOrDefault
     ;
 
 insertData
@@ -222,8 +222,8 @@ usingClause
     : USING NAMED? iri
     ;
 
-graphOrDefault
-    : DEFAULT | GRAPH? iri
+graphOrVarOrDefault
+    : DEFAULT | GRAPH? varOrIRI
     ;
 
 graphRef

--- a/jopa-impl/src/test/java/cz/cvut/kbss/jopa/query/sparql/SparqlQueryParsingAndAssemblyTest.java
+++ b/jopa-impl/src/test/java/cz/cvut/kbss/jopa/query/sparql/SparqlQueryParsingAndAssemblyTest.java
@@ -302,6 +302,22 @@ public class SparqlQueryParsingAndAssemblyTest {
     }
 
     @Test
+    void parseAndAssembleAllowsVariableInMoveGraphStatement() {
+        this.sut = queryParser.parseQuery("MOVE GRAPH ?source TO ?destination");
+        final URI sourceGraphUri = Generators.createIndividualIdentifier();
+        final URI destinationGraphUri = Generators.createIndividualIdentifier();
+        sut.setParameter(sut.getParameter("source"), sourceGraphUri);
+        sut.setParameter(sut.getParameter("destination"), destinationGraphUri);
+
+        final String result = sut.assembleQuery();
+        final String expected = "MOVE GRAPH " +
+                IdentifierTransformer.stringifyIri(sourceGraphUri) +
+                " TO " +
+                IdentifierTransformer.stringifyIri(destinationGraphUri);
+        assertEquals(expected , result);
+    }
+
+    @Test
     void parseAndAssembleSupportsVariablesInTripleTerms() {
         final URI xUri = Generators.createIndividualIdentifier();
         this.sut = queryParser.parseQuery("SELECT ?annotationProperty ?annotationValue WHERE { << ?x ?property ?value >> ?annotationProperty ?annotationValue . }");


### PR DESCRIPTION
A possible fix for #413 

Renamed `graphOrDefault` to `graphOrVarOrDefault` and added a variable to possible values. 

Added test for variable parsing in move graph query.